### PR TITLE
Follow XDG spec for config directory

### DIFF
--- a/cleanlab_cli/settings.py
+++ b/cleanlab_cli/settings.py
@@ -26,9 +26,9 @@ class CleanlabSettings:
 
     @staticmethod
     def get_cleanlab_dir():
-        XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", None)
-        CONFIG_HOME = XDG_CONFIG_HOME if XDG_CONFIG_HOME else os.environ.get("HOME")
-        cleanlab_dir = os.path.expanduser(os.path.join(CONFIG_HOME, ".cleanlab"))
+        XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME")
+        CONFIG_HOME = XDG_CONFIG_HOME if XDG_CONFIG_HOME else "~/.config"
+        cleanlab_dir = os.path.expanduser(os.path.join(CONFIG_HOME, "cleanlab"))
         return cleanlab_dir
 
     @staticmethod


### PR DESCRIPTION
From https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html:

> If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.

This patch also switches the directory from ".cleanlab" to just "cleanlab". There's no need to prepend a "." when it's already in the (hidden) config directory.