### PR TITLE
Read streaming array instead of records

### DIFF
--- a/cleanlab_cli/classes/excel_dataset.py
+++ b/cleanlab_cli/classes/excel_dataset.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from .dataset import Dataset
+from cleanlab_cli.classes.dataset import Dataset
 import pyexcel
 import pandas as pd
 
@@ -11,12 +11,14 @@ class ExcelDataset(Dataset):
             yield r
 
     def read_streaming_values(self):
-        for r in pyexcel.iget_records(file_name=self.filepath):
-            # TODO optimize
-            yield r.values()
+        stream = pyexcel.iget_array(file_name=self.filepath)
+        next(stream)  # skip header row
+        for r in stream:
+            yield r
 
     def read_file_as_dataframe(self):
         return pd.read_excel(self.filepath, keep_default_na=True)
 
     def get_columns(self) -> List[str]:
-        return super().get_columns()
+        stream = pyexcel.iget_array(file_name=self.filepath)
+        return next(stream)

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -302,14 +302,15 @@ def propose_schema(
 
     # dataset = []
     rows = []
-    for idx, row in enumerate(dataset.read_streaming_records()):
+    for idx, row in enumerate(dataset.read_streaming_values()):
         if idx >= max_rows_checked:
             break
         if idx < sample_size:
-            rows.append(dict(row.items()))
+            rows.append(row)
         else:
-            if random.random() < (sample_size + 1) / (idx + 1):
-                rows[random.randint(0, sample_size - 1)] = dict(row.items())
+            random_idx = random.randint(0, idx)
+            if random_idx < sample_size:
+                rows[random_idx] = rows
 
     df = pd.DataFrame(rows, columns=columns)
     retval: Dict[str, Any] = dict()

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -310,9 +310,8 @@ def propose_schema(
         else:
             random_idx = random.randint(0, idx)
             if random_idx < sample_size:
-                rows[random_idx] = rows
-
-    df = pd.DataFrame(rows, columns=columns)
+                rows[random_idx] = row
+    df = pd.DataFrame(data=rows, columns=columns)
     retval: Dict[str, Any] = dict()
     retval["metadata"] = {}
     retval["fields"] = {}


### PR DESCRIPTION
- Optimize reading of datasets by reading rows as values rather than as key-value pairs
- Optimize `ExcelDataset` to use `iget_array` instead of `iget_records`, same idea as above
