### PR TITLE
--all flag to allow downloading of all Cleanlab columns

### DIFF
--- a/cleanlab_cli/api_service.py
+++ b/cleanlab_cli/api_service.py
@@ -71,15 +71,16 @@ def upload_rows(api_key, dataset_id, rows):
     handle_api_error(res)
 
 
-def download_clean_labels(api_key, cleanset_id):
+def download_cleanlab_columns(api_key, cleanset_id, all=False):
     """
 
     :param api_key:
     :param cleanset_id:
+    :param all: whether to download all Cleanlab columns or just the clean_label column
     :return: return (rows, id_column)
     """
     res = requests.get(
-        base_url + f"/cleansets/{cleanset_id}/clean_label", data=dict(api_key=api_key)
+        base_url + f"/cleansets/{cleanset_id}/columns?all={all}", data=dict(api_key=api_key)
     )
     handle_api_error(res)
     return res.json()["rows"]


### PR DESCRIPTION
`cleanlab cleanset download` now accepts an `--all` flag to download all Cleanlab columns, instead of just the `clean_label` column.