### PR TITLE
Version handling details

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,16 +60,16 @@ To upload to PyPi:
 
 ## Versioning
 
-For users, there is only one version number to keep track of: the CLI package version.
+For *users*, there is only one version number to keep track of: the CLI package version.
 
-For developers, there are four version numbers to keep track of:
+For *developers*, there are four version numbers to keep track of:
 
 1. The CLI package version
 2. Cleanlab Studio CLI API version (currently v0)
 3. The schema version number
 4. The CLI settings version number
 
-The latest version numbers for (1), (2), (4)
+The latest version numbers for (1), (2), and (4)
 are [stored in version.py](https://github.com/cleanlab/cleanlab-cli/blob/main/cleanlab_cli/version.py).
 
 ### Minimum supported versions
@@ -109,7 +109,7 @@ interfaces with the settings or schema.
 
 ----
 
-Whenever the CLI API is updated, update the minimum supported CLI version when there is a change in the API, which
+Whenever the **CLI API is updated**, update the minimum supported CLI version when there is a change in the API, which
 changes the interface between API and CLI in a way that breaks compatibility. Every endpoint in the CLI API is used by
 the CLI in some way, so any change must be followed by the question:
 Does this change in the API break the oldest supported versions of the CLI?

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,5 @@
 ## View performance benchmarks
+
 https://cleanlab.github.io/cleanlab-cli/dev/bench/
 
 ## Development
@@ -57,13 +58,76 @@ To upload to PyPi:
 
 1. twine upload dist/*
 
-## Updating version numbers
+## Versioning
 
-The package version number is used in several parts of the CLI to validate the client. Every time the version number is
-incremented, these parts of the codebase need to be updated:
+For users, there is only one version number to keep track of: the CLI package version.
+
+For developers, there are four version numbers to keep track of:
+
+1. The CLI package version
+2. Cleanlab Studio CLI API version (currently v0)
+3. The schema version number
+4. The CLI settings version number
+
+The latest version numbers for (1), (2), (4)
+are [stored in version.py](https://github.com/cleanlab/cleanlab-cli/blob/main/cleanlab_cli/version.py).
+
+### Minimum supported versions
+
+Each **version of the CLI** supports some:
+
+- `MIN_SCHEMA_VERSION`: Minimum schema version number
+- `MIN_SETTINGS_VERSION`: Minimum CLI settings version number
+
+If a user provides a schema with version number < `MIN_SCHEMA_VERSION`, it cannot be used. A new one must be generated.
+
+If a CLI settings file has a version number < `MIN_SETTINGS_VERSION`, it cannot be used. The CLI will attempt to migrate
+it (with the user's permission).
+
+Similarly, each version of the **Cleanlab Studio CLI API** supports some:
+
+- `MIN_CLI_VERSION`: Minimum CLI version number
+
+The CLI, upon initializing, pings the CLI API with its version number to check if it is compatible. If the CLI
+version < `MIN_CLI_VERSION`, then the user is prompted to upgrade their `cleanlab-cli` package.
+
+### When to increment the minimum supported versions
+
+For each **release of the CLI**, update the minimum supported versions whenever there is a change in how the CLI
+interfaces with the settings or schema.
+
+#### Examples of when to update
+
+- The CLI now expects the Settings / Schema to have a new key, so older settings / schema would be incompatible with the
+  new CLI.
+
+#### Examples of when not to update
+
+- CLI does additional checks on schema that it did not do before, but the schema format is unchanged
+- CLI adds new functionality for interfacing with Cleanlab Studio CLI API, but no new behavior is introduced for
+  interfacing with settings / schema
+
+----
+
+Whenever the CLI API is updated, update the minimum supported CLI version when there is a change in the API, which
+changes the interface between API and CLI in a way that breaks compatibility. Every endpoint in the CLI API is used by
+the CLI in some way, so any change must be followed by the question:
+Does this change in the API break the oldest supported versions of the CLI?
+
+#### Examples of when to update
+
+- API endpoint returns different values from before — `int` vs `string`, `tuple` vs `dict`
+
+#### Examples of when not to update
+
+1. Refactoring internal implementation but the endpoints and their returned values do not change
+2. API supports **additional** endpoints compared to before
+3. API endpoints return values change but not in a compatibility breaking way — e.g. returns a `dict` with an additional
+   key. Depending on how the CLI uses the `dict` — check `dict` length vs fetch expected keys — this may be fine!
+
+## Incrementing the package version number
+
+Every time the version number is incremented, these parts of the codebase need to be updated:
 
 1. `cleanlab_cli/version.py`
 2. `README.md`
-3. `VALID_VERSIONS` in `cleanlab_cli/settings.py`
-4. `cleanlab_cli/tests/resources/schemas/sample_schema.json`
-5. `check_client_version` in Cleanlab Studio's `cli_api.py`

--- a/cleanlab_cli/__init__.py
+++ b/cleanlab_cli/__init__.py
@@ -1,4 +1,4 @@
-from .version import __version__, VALID_VERSIONS
+from .version import __version__, MIN_SCHEMA_VERSION, MIN_SETTINGS_VERSION
 from . import login
 from . import cleanset
 from . import dataset

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -15,7 +15,9 @@ from typing import (
 
 import pandas as pd
 from pandas import NaT
+import semver
 
+from cleanlab_cli import MIN_SCHEMA_VERSION
 from cleanlab_cli.click_helpers import progress, success, info, abort
 from cleanlab_cli.dataset.schema_types import (
     DATA_TYPES_TO_FEATURE_TYPES,
@@ -79,6 +81,14 @@ def validate_schema(schema, columns: Collection[str]):
     for key in ["fields", "metadata", "version"]:
         if key not in schema:
             raise KeyError(f"Schema is missing '{key}' key.")
+
+    # check schema version validity
+    schema_version = schema["version"]
+    if semver.compare(MIN_SCHEMA_VERSION, schema_version) == 1:  # min schema > schema_version
+        raise ValueError(
+            "This schema version is incompatible with this version of the CLI. "
+            "A new schema should be generated using 'cleanlab dataset schema generate'"
+        )
 
     schema_columns = set(schema["fields"])
     columns = set(columns)

--- a/cleanlab_cli/settings.py
+++ b/cleanlab_cli/settings.py
@@ -1,8 +1,9 @@
 import json
 import os
 from typing import Optional
+import semver
 
-from cleanlab_cli import __version__, VALID_VERSIONS
+from cleanlab_cli import __version__, MIN_SETTINGS_VERSION
 
 
 class CleanlabSettings:
@@ -70,15 +71,9 @@ class CleanlabSettings:
         self.save()
 
     def validate_version(self):
-        # list of sem vers for which a migration needs to be run
-        MIGRATION_VERSIONS = []
-        if self.version not in VALID_VERSIONS:
-            if self.version in MIGRATION_VERSIONS:
-                raise ValueError("Settings file must be migrated or re-generated.")
-            else:
-                raise ValueError(
-                    "Unrecognized Cleanlab settings version. Settings file must be re-generated."
-                )
+        if semver.compare(MIN_SETTINGS_VERSION, self.version) == 1:
+            # TODO add proper settings migrations
+            raise ValueError("Settings file must be migrated or re-generated.")
 
     def save(self):
         with open(CleanlabSettings.get_settings_filepath(), "w") as f:

--- a/cleanlab_cli/version.py
+++ b/cleanlab_cli/version.py
@@ -1,2 +1,7 @@
 __version__ = "0.1.3"
-VALID_VERSIONS = ["0.1.0", "0.1.1", "0.1.2", "0.1.3"]
+
+SCHEMA_VERSION = "0.1.0"
+MIN_SCHEMA_VERSION = "0.1.0"
+
+SETTINGS_VERSION = "0.1.0"
+MIN_SETTINGS_VERSION = "0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "tqdm>=4.64.0",
         "ijson>=3.1.4",
         "jsonstreams>=0.6.0",
+        "semver>=2.13.0",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
1. Added full details about how versioning is handled for CLI in `development.md`
2. Based on (1), added `MIN_SCHEMA_VERSION` and `MIN_SETTINGS_VERSION` to `version.py` and removed `VALID_VERSIONS`
3. Added `semver` package as dependency, for checking schemas / settings against CLI min versions

Settings migration support will be added in a future PR. Not useful now, given the simplicity of CLI settings.