### PR TITLE
Use asyncio.sleep(0) to yield control

### DIFF
--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -283,7 +283,6 @@ async def upload_rows(
                         )
                     )
                 )
-
                 payload = []
 
                 # avoid race condition when creating table
@@ -293,7 +292,8 @@ async def upload_rows(
                     first_upload = False
 
             row = upload_queue.get()
-            await asyncio.sleep(0.0001)
+            # yield control
+            await asyncio.sleep(0)
 
         # upload remaining rows
         if len(payload) > 0:


### PR DESCRIPTION
We use `asyncio.sleep(0.0001)` to yield control so that upload tasks can be dispatched if present. However, this 0.0001s sleep time is wasteful and can result in significant amount of wasted time when there are no upload tasks available.

For a 100MB dataset (Tweets.csv, 448K rows), a sleep on every row results in ~45s of wasted time.

We can just use `asyncio.sleep(0)` to yield control, instead of specifying this small wait time. This seems to be the recommended pattern, based on this thread: https://github.com/python/asyncio/issues/284#issuecomment-153909204

Testing on 100MB Tweets, the overall upload time went from 90s to 60s. 