### PR TITLE
Allow overriding API URL with an env var

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,6 +8,7 @@ https://cleanlab.github.io/cleanlab-cli/dev/bench/
    directory. Changes to the code are reflected automatically in the CLI.
 2. `Makefile` contains sample commands for quick installation and testing, though you will have to specify filepaths and
    API keys manually.
+3. Run `export CLEANLAB_API_URL="http://localhost:8500/api/cli/v0"` so that API requests are made on your local machine
 
 ## Formatting
 

--- a/cleanlab_cli/api_service.py
+++ b/cleanlab_cli/api_service.py
@@ -4,6 +4,7 @@ Methods for interacting with the command line server API
 """
 import gzip
 import json
+import os
 from typing import Dict
 
 import requests
@@ -11,10 +12,8 @@ import requests
 from cleanlab_cli.click_helpers import abort, warn
 from cleanlab_cli import __version__
 
-base_url = "https://api.cleanlab.ai/api/cli/v0"
 
-
-# base_url = "http://localhost:8500/api/cli/v0"
+base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api/cli/v0")
 
 
 def handle_api_error(res: requests.Response, show_warning=False):


### PR DESCRIPTION
With this patch, rather than modifying the `api_service.py` file for local development, a developer can run the following in their shell:

```bash
export CLEANLAB_API_URL="http://localhost:8500/api/cli/v0"
```