### PR TITLE
float conversion for timestamp and regex for float string

### DIFF
--- a/cleanlab_cli/dataset/schema_types.py
+++ b/cleanlab_cli/dataset/schema_types.py
@@ -14,3 +14,10 @@ PYTHON_TYPES_TO_READABLE_STRING = {
     bool: "boolean",
     Decimal: "float",
 }
+
+DATA_TYPES_TO_PYTHON_TYPES = {
+    "string": str,
+    "float": float,
+    "integer": int,
+    "boolean": bool,
+}

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -446,6 +446,12 @@ def save_feedback(feedback, filename):
 
 
 def extract_float_value(column_value):
+    """
+    Floating point: Decimal number containing a decimal point, optionally preceded by a + or - sign
+    and optionally followed by the e or E character and a decimal number.
+
+    Reference: https://docs.python.org/3/library/re.html#simulating-scanf
+    """
     float_regex_pattern = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
     float_value = re.search(float_regex_pattern, column_value)
     return float_value.group(0) if float_value else ""

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -446,7 +446,6 @@ def save_feedback(feedback, filename):
 
 
 def extract_float_value(column_value):
-    float_regex_pattern = "[-+]? (?: (?: \d* \. \d+ ) | (?: \d+ \.? ) )(?: [Ee] [+-]? \d+ ) ?"
-    regex = re.compile(float_regex_pattern, re.VERBOSE)
-    float_value = re.search(regex, column_value)
+    float_regex_pattern = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
+    float_value = re.search(float_regex_pattern, column_value)
     return float_value.group(0) if float_value else ""


### PR DESCRIPTION
This should improve how we handle a couple corner cases we noticed during testing.

If float is chosen as data type:

  1) convert to float before parsing with pandas.Timestamp(), 
  Ex:
  _expected datetime but unable to parse '1.413324556E+09' with string type_
  
  2) extract floating number from a string
  Ex:
  _expected 'float' but got '34%' with string type_