### PR TITLE
convert to str explicitly

### DIFF
--- a/cleanlab_cli/classes/excel_dataset.py
+++ b/cleanlab_cli/classes/excel_dataset.py
@@ -21,4 +21,4 @@ class ExcelDataset(Dataset):
 
     def get_columns(self) -> List[str]:
         stream = pyexcel.iget_array(file_name=self.filepath)
-        return next(stream)
+        return [str(col) for col in next(stream)]

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -27,7 +27,6 @@ from cleanlab_cli.util import (
     get_filename,
     dump_json,
 )
-import time
 
 ALLOWED_EXTENSIONS = [".csv", ".xls", ".xlsx"]
 
@@ -42,7 +41,6 @@ def _find_best_matching_column(target_column: str, columns: List[str]) -> Option
     :return:
     """
     assert len(columns) > 0, "list of columns is empty"
-    columns = [str(c) for c in columns]
     poss = []
     for c in columns:
         if c.lower() == target_column:

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -42,6 +42,7 @@ def _find_best_matching_column(target_column: str, columns: List[str]) -> Option
     :return:
     """
     assert len(columns) > 0, "list of columns is empty"
+    columns = [str(c) for c in columns]
     poss = []
     for c in columns:
         if c.lower() == target_column:


### PR DESCRIPTION
We received a bug in production for cleanlab-studio.
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/34938734/186063152-db869a98-4918-4d0b-ad16-70d0a0acc88b.png">

The bug originated from
`File "/usr/local/lib/python3.10/site-packages/cleanlab_cli/dataset/schema_helpers.py", line 47, in _find_best_matching_column`

The utility expects string columns but received int columns.
This will fix the bug for now. @calebchiam - Maybe you will have more context on why the function received int columns in the first place. Let me know if there is a better solution.

**Limitation**
This will fail if the columns are not castable to string