### PR TITLE
Tag and release gh action

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -19,6 +19,6 @@ jobs:
           pip install --upgrade build
           pip install --upgrade twine
       - name: Build package
-          python3 -m build
+        run: python3 -m build
       - name: Release package
         run: twine upload dist/* -u TOKEN -p ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,24 @@
+name: Tag and release new PyPi package
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v0.*
+
+jobs:
+  build-and-releasepypi-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3
+        uses: actions/setup-python@v3
+      - name: Install dependencies
+        run: |
+          pip install --upgrade build
+          pip install --upgrade twine
+      - name: Build package
+          python3 -m build
+      - name: Release package
+        run: twine upload dist/* -u TOKEN -p ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Introduces a new GH action workflow that builds the `cleanlab-cli` package and uploads it to PyPi, every time a release tag commit is pushed to the `main` branch.