### PR TITLE
Refactor: TypedDict -> Dataclass, Literal -> Enum

### DIFF
--- a/cleanlab_cli/api_service.py
+++ b/cleanlab_cli/api_service.py
@@ -12,8 +12,9 @@ import aiohttp
 import requests
 
 from cleanlab_cli.click_helpers import abort, warn
+from cleanlab_cli.dataset.schema_types import Schema
 from cleanlab_cli import __version__
-from cleanlab_cli.types import JSONDict, Schema, IDType
+from cleanlab_cli.types import JSONDict, IDType
 
 base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api/cli/v0")
 
@@ -34,12 +35,12 @@ def handle_api_error_from_json(res_json: JSONDict, show_warning: bool = False) -
 
 
 def initialize_dataset(api_key: str, schema: Schema) -> str:
-    fields = list(schema["fields"])
-    data_types = [spec["data_type"] for spec in schema["fields"].values()]
-    feature_types = [spec["feature_type"] for spec in schema["fields"].values()]
-    id_column = schema["metadata"]["id_column"]
-    modality = schema["metadata"]["modality"]
-    dataset_name = schema["metadata"]["name"]
+    fields = list(schema.fields)
+    data_types = [spec.data_type.value for spec in schema.fields.values()]
+    feature_types = [spec.feature_type.value for spec in schema.fields.values()]
+    id_column = schema.metadata.id_column
+    modality = schema.metadata.modality.value
+    dataset_name = schema.metadata.name
 
     res = requests.post(
         base_url + "/datasets",

--- a/cleanlab_cli/dataset/schema.py
+++ b/cleanlab_cli/dataset/schema.py
@@ -10,7 +10,7 @@ from cleanlab_cli.dataset.schema_helpers import (
 )
 from cleanlab_cli.dataset import upload_helpers
 from cleanlab_cli.decorators.previous_state import PreviousState
-from cleanlab_cli.types import Schema, Modality, IDType, CommandState
+from cleanlab_cli.types import Schema, Modality, IDType, CommandState, MODALITIES
 from cleanlab_cli.util import init_dataset_from_filepath
 from cleanlab_cli.decorators import previous_state
 import json
@@ -127,7 +127,7 @@ def check_dataset_command(
     "--modality",
     "--m",
     prompt=True,
-    type=click.Choice(["text", "tabular"]),
+    type=click.Choice(MODALITIES),
     help="Dataset modality: text or tabular",
 )
 @click.option(

--- a/cleanlab_cli/dataset/schema.py
+++ b/cleanlab_cli/dataset/schema.py
@@ -168,7 +168,7 @@ def generate_schema_command(
     prev_state.init_state(command_state)
 
     proposed_schema = propose_schema(filepath, columns, id_column, modality, name)
-    click.echo(json.dumps(proposed_schema, indent=2))
+    click.echo(json.dumps(proposed_schema.to_dict(), indent=2))
     if not output:
         output = click_helpers.confirm_save_prompt_filepath(
             save_message="Would you like to save the generated schema?",

--- a/cleanlab_cli/dataset/schema.py
+++ b/cleanlab_cli/dataset/schema.py
@@ -10,7 +10,8 @@ from cleanlab_cli.dataset.schema_helpers import (
 )
 from cleanlab_cli.dataset import upload_helpers
 from cleanlab_cli.decorators.previous_state import PreviousState
-from cleanlab_cli.types import Schema, Modality, IDType, CommandState, MODALITIES
+from cleanlab_cli.dataset.upload_types import ValidationWarning
+from cleanlab_cli.types import CommandState, MODALITIES
 from cleanlab_cli.util import init_dataset_from_filepath
 from cleanlab_cli.decorators import previous_state
 import json
@@ -42,7 +43,7 @@ def validate_schema_command(
         dataset = init_dataset_from_filepath(filepath)
         cols = dataset.get_columns()
     else:
-        cols = list(loaded_schema["fields"])
+        cols = list(loaded_schema.fields)
     try:
         validate_schema(loaded_schema, cols)
     except ValueError as e:
@@ -87,8 +88,7 @@ def check_dataset_command(
         if row_id:
             seen_ids.add(row_id)
 
-    log_warnings: Iterable[Sized] = cast(Iterable[Sized], list(log.values()))
-    total_warnings = sum(len(warnings) for warnings in log_warnings)
+    total_warnings = sum([len(log.get(warning_type)) for warning_type in ValidationWarning])
     if total_warnings == 0:
         success("\nNo type issues were found when checking your dataset. Nice!")
     else:
@@ -141,7 +141,7 @@ def generate_schema_command(
     filepath: Optional[str],
     output: Optional[str],
     id_column: Optional[str],
-    modality: Optional[Modality],
+    modality: Optional[str],
     name: Optional[str],
 ) -> None:
     if filepath is None:

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -6,7 +6,7 @@ import json
 import os.path
 import pathlib
 import random
-from typing import Any, Optional, Dict, List, Collection, Tuple
+from typing import Any, Optional, Dict, List, Collection, Tuple, Sized
 
 import pandas as pd
 from pandas import NaT
@@ -16,16 +16,13 @@ from cleanlab_cli import MIN_SCHEMA_VERSION, SCHEMA_VERSION, MAX_SCHEMA_VERSION
 from cleanlab_cli.click_helpers import progress, success, info, abort
 from cleanlab_cli.dataset.schema_types import (
     DATA_TYPES_TO_FEATURE_TYPES,
-)
-from cleanlab_cli.types import (
+    FeatureType,
     Schema,
     DataType,
-    FeatureType,
-    Modality,
     FieldSpecification,
     SchemaMetadata,
-    DATATYPES,
 )
+from cleanlab_cli.types import Modality
 from cleanlab_cli.util import (
     init_dataset_from_filepath,
     get_filename,
@@ -60,30 +57,32 @@ def _find_best_matching_column(target_column: str, columns: List[str]) -> Option
 
 def load_schema(filepath: str) -> Schema:
     with open(filepath, "r") as f:
-        schema: Schema = json.load(f)
+        schema_dict = json.load(f)
+        schema: Schema = Schema.create(
+            metadata=schema_dict["metadata"],
+            fields=schema_dict["fields"],
+            version=schema_dict["version"],
+        )
         return schema
 
 
 def validate_schema(schema: Schema, columns: Collection[str]) -> None:
     """
+
     Checks that:
     (1) all schema column names are strings
     (2) all schema columns exist in the dataset columns
     (3) all schema column types are recognized
+
+    Note that schema initialization already checks that all keys are present and that fields are valid.
 
     :param schema:
     :param columns: full list of columns in dataset
     :return: raises a ValueError if any checks fail
     """
 
-    # Check for completeness and basic type correctness
-    ## Check that schema is complete with fields, metadata, and version
-    for key in ["fields", "metadata", "version"]:
-        if key not in schema:
-            raise KeyError(f"Schema is missing '{key}' key.")
-
     # check schema version validity
-    schema_version = schema["version"]
+    schema_version = schema.version
     if semver.compare(MIN_SCHEMA_VERSION, schema_version) == 1:  # min schema > schema_version
         raise ValueError(
             "This schema version is incompatible with this version of the CLI. "
@@ -94,47 +93,19 @@ def validate_schema(schema: Schema, columns: Collection[str]) -> None:
             "CLI is not up to date with your schema version. Run 'pip install --upgrade cleanlab-cli'."
         )
 
-    schema_columns = set(schema["fields"])
+    schema_columns = set(schema.fields)
     columns = set(columns)
-
-    ## Check that metadata is complete
-    metadata = schema["metadata"]
-    for key in ["id_column", "modality", "name"]:
-        if key not in metadata:
-            raise KeyError(f"Metadata is missing the '{key}' key.")
-
-    ## Check that schema fields are strings
-    for col in schema_columns:
-        if not isinstance(col, str):
-            raise ValueError(
-                f"All schema columns must be strings. Found invalid column name: {col}"
-            )
-        if col == "":
-            raise ValueError("Schema columns cannot be empty strings.")
+    metadata = schema.metadata
 
     ## Check that the dataset has all columns specified in the schema
     if not schema_columns.issubset(columns):
         raise ValueError(f"Dataset is missing schema columns: {schema_columns - columns}")
 
-    ## Check that each field has a feature_type that matches the base type
-    for spec in schema["fields"].values():
-        column_type = spec["data_type"]
-        column_feature_type = spec.get("feature_type", None)
-        if column_type not in DATATYPES:
-            raise ValueError(f"Unrecognized column data type: {column_type}")
-
-        if column_feature_type:
-            if column_feature_type not in DATA_TYPES_TO_FEATURE_TYPES[column_type]:
-                raise ValueError(
-                    f"Invalid column feature type: '{column_feature_type}'. Accepted categories for"
-                    f" type '{column_type}' are: {DATA_TYPES_TO_FEATURE_TYPES[column_type]}"
-                )
-
     # Advanced validation checks: this should be aligned with ConfirmSchema's validate() function
     ## Check that specified ID column has the feature_type 'identifier'
-    id_column_name = metadata["id_column"]
-    id_column_spec_feature_type = schema["fields"][id_column_name]["feature_type"]
-    if id_column_spec_feature_type != "identifier":
+    id_column_name = metadata.id_column
+    id_column_spec_feature_type = schema.fields[id_column_name].feature_type
+    if id_column_spec_feature_type != FeatureType.identifier:
         raise ValueError(
             f"ID column field {id_column_name} must have feature type: 'identifier', but has"
             f" feature type: '{id_column_spec_feature_type}'"
@@ -142,7 +113,7 @@ def validate_schema(schema: Schema, columns: Collection[str]) -> None:
 
     ## Check that there exists at least one categorical column (to be used as label)
     has_categorical = any(
-        spec["feature_type"] == "categorical" for spec in schema["fields"].values()
+        spec.feature_type == FeatureType.categorical for spec in schema.fields.values()
     )
     if not has_categorical:
         raise ValueError(
@@ -150,11 +121,11 @@ def validate_schema(schema: Schema, columns: Collection[str]) -> None:
         )
 
     ## If tabular modality, check that there are at least two variable (i.e. categorical, numeric, datetime) columns
-    modality = metadata["modality"]
-    variable_fields = {"categorical", "numeric", "datetime"}
-    if modality == "tabular":
+    modality = metadata.modality
+    variable_fields = {FeatureType.categorical, FeatureType.numeric, FeatureType.datetime}
+    if modality == Modality.tabular:
         num_variable_columns = sum(
-            int(spec["feature_type"] in variable_fields) for spec in schema["fields"].values()
+            int(spec.feature_type in variable_fields) for spec in schema.fields.values()
         )
         if num_variable_columns < 2:
             raise ValueError(
@@ -163,12 +134,10 @@ def validate_schema(schema: Schema, columns: Collection[str]) -> None:
             )
 
     ## If text modality, check that at least one column has feature type 'text'
-    elif modality == "text":
-        has_text = any(spec["feature_type"] == "text" for spec in schema["fields"].values())
+    elif modality == Modality.text:
+        has_text = any(spec.feature_type == FeatureType.text for spec in schema.fields.values())
         if not has_text:
             raise ValueError("Dataset modality is text, but none of the fields is a text column.")
-    else:
-        raise ValueError(f"Unsupported dataset modality: {modality}")
 
 
 def multiple_separate_words_detected(values: Collection[Any]) -> bool:
@@ -182,14 +151,14 @@ def is_filepath(string: str, check_existing: bool = False) -> bool:
     return pathlib.Path(string).suffix != "" and " " not in string
 
 
-def get_validation_sample_size(values):
+def get_validation_sample_size(values: Sized) -> int:
     return max(20, len(values))
 
 
 def _values_are_datetime(values: Collection[Any]) -> bool:
     try:
         # check for datetime first
-        val_sample = random.sample(list(values), get_validation_sample_size(20))
+        val_sample = random.sample(list(values), get_validation_sample_size(values))
         for s in val_sample:
             res = pd.to_datetime(s)
             if res is NaT:
@@ -212,7 +181,7 @@ def _values_are_integers(values: Collection[Any]) -> bool:
 
 def _values_are_floats(values: Collection[Any]) -> bool:
     try:
-        val_sample = random.sample(list(values), get_validation_sample_size(20))
+        val_sample = random.sample(list(values), get_validation_sample_size(values))
         for s in val_sample:
             float(s)
     except Exception:
@@ -234,7 +203,7 @@ def infer_types(values: Collection[Any]) -> Tuple[DataType, FeatureType]:
 
     :param values: a Collection of data values (that are not null and not empty string)
     """
-    counts = {"string": 0, "integer": 0, "float": 0, "boolean": 0}
+    counts = {DataType.string: 0, DataType.integer: 0, DataType.float: 0, DataType.boolean: 0}
     ID_RATIO_THRESHOLD = 0.97  # lowerbound
     CATEGORICAL_RATIO_THRESHOLD = 0.20  # upperbound
 
@@ -243,63 +212,63 @@ def infer_types(values: Collection[Any]) -> Tuple[DataType, FeatureType]:
         if v == "":
             continue
         if isinstance(v, str):
-            counts["string"] += 1
+            counts[DataType.string] += 1
         elif isinstance(v, float):
-            counts["float"] += 1
+            counts[DataType.float] += 1
         elif isinstance(v, int):
-            counts["integer"] += 1
+            counts[DataType.integer] += 1
         elif isinstance(v, bool):
-            counts["boolean"] += 1
+            counts[DataType.integer] += 1
         else:
             raise ValueError(f"Value {v} has an unrecognized type: {type(v)}")
 
-    ratios: Dict[str, float] = {k: v / len(values) for k, v in counts.items()}
-    max_count_type = max(ratios.items(), key=lambda kv: kv[1])[0]
+    ratios: Dict[DataType, float] = {k: v / len(values) for k, v in counts.items()}
+    max_count_type = max(ratios, key=lambda k: ratios[k])
 
     # preliminary check: ints/floats may be loaded as strings
     if max_count_type:
         if _values_are_integers(values):
-            max_count_type = "integer"
+            max_count_type = DataType.integer
         elif _values_are_floats(values):
-            max_count_type = "float"
+            max_count_type = DataType.float
 
-    if max_count_type == "string":
+    if max_count_type == DataType.string:
         if _values_are_datetime(values):
-            return "string", "datetime"
+            return DataType.string, FeatureType.datetime
         # is string type
         if ratio_unique >= ID_RATIO_THRESHOLD:
             # almost all unique values, i.e. either ID, text
             if multiple_separate_words_detected(values):
-                return "string", "text"
+                return DataType.string, FeatureType.text
             else:
                 if _values_are_filepaths(values):
-                    return "string", "filepath"
-                return "string", "identifier"
+                    return DataType.string, FeatureType.filepath
+                return DataType.string, FeatureType.identifier
         elif ratio_unique <= CATEGORICAL_RATIO_THRESHOLD:
-            return "string", "categorical"
+            return DataType.string, FeatureType.categorical
         else:
-            return "string", "text"
+            return DataType.string, FeatureType.text
 
-    elif max_count_type == "integer":
+    elif max_count_type == DataType.integer:
         if ratio_unique >= ID_RATIO_THRESHOLD:
-            return "string", "identifier"  # identifiers are always strings
+            return DataType.integer, FeatureType.identifier
         elif ratio_unique <= CATEGORICAL_RATIO_THRESHOLD:
-            return "integer", "categorical"
+            return DataType.integer, FeatureType.categorical
         else:
-            return "integer", "numeric"
-    elif max_count_type == "float":
-        return "float", "numeric"
-    elif max_count_type == "boolean":
-        return "string", "categorical"
+            return DataType.integer, FeatureType.numeric
+    elif max_count_type == DataType.float:
+        return DataType.float, FeatureType.numeric
+    elif max_count_type == DataType.boolean:
+        return DataType.boolean, FeatureType.boolean
     else:
-        return "string", "text"
+        return DataType.string, FeatureType.text
 
 
 def propose_schema(
     filepath: str,
     columns: Optional[Collection[str]] = None,
     id_column: Optional[str] = None,
-    modality: Optional[Modality] = None,
+    modality: Optional[str] = None,
     name: Optional[str] = None,
     sample_size: int = 10000,
     max_rows_checked: int = 200000,
@@ -313,7 +282,7 @@ def propose_schema(
     :param columns: columns to generate a schema for
     :param id_column: ID column name
     :param name: name of dataset
-    :param modality: text or tabular
+    :param modality: data modality
     :param sample_size: default of 1000
     :param max_rows_checked: max rows to sample from
     :return:
@@ -331,9 +300,9 @@ def propose_schema(
 
     if modality is None:
         if len(columns) > 5:
-            modality = "tabular"
+            modality = Modality.tabular.value
         else:
-            modality = "text"
+            modality = Modality.text.value
 
     # dataset = []
     rows = []
@@ -348,11 +317,8 @@ def propose_schema(
                 rows[random_idx] = row
     df = pd.DataFrame(data=rows, columns=columns)
 
-    # initialize to defaults to pass type check
-    retval: Schema = dict(
-        metadata=dict(id_column="", modality="text", name=""), fields={}, version=""
-    )
-
+    schema_dict = dict()
+    fields_dict = dict()
     for column_name in columns:
         if column_name == "":
             continue
@@ -360,21 +326,21 @@ def propose_schema(
         column_values = [v for v in column_values if v != ""]
 
         if len(column_values) == 0:  # all values in column are empty, give default string[text]
-            retval["fields"][column_name] = {"data_type": "string", "feature_type": "text"}
+            fields_dict[column_name] = {"data_type": "string", "feature_type": "text"}
             continue
 
         col_data_type, col_feature_type = infer_types(column_values)
+        fields_dict[column_name] = dict(
+            data_type=col_data_type.value, feature_type=col_feature_type.value
+        )
 
-        field_spec: FieldSpecification = {
-            "data_type": col_data_type,
-            "feature_type": col_feature_type,
-        }
-
-        retval["fields"][column_name] = field_spec
+    schema_dict["fields"] = fields_dict
 
     if id_column is None:
         id_columns = [
-            k for k, spec in retval["fields"].items() if spec["feature_type"] == "identifier"
+            k
+            for k, spec in schema_dict["fields"].items()
+            if spec["feature_type"] == FeatureType.identifier.value
         ]
         if len(id_columns) == 0:
             id_columns = list(columns)
@@ -383,34 +349,29 @@ def propose_schema(
         if id_column not in columns:
             abort(f"ID column '{id_column}' does not exist in the dataset.")
 
-    assert id_column is not None  # TODO better way to show mypy that id_column is a string?
+    assert id_column is not None
 
-    metadata: SchemaMetadata = {
-        "id_column": id_column,
-        "modality": modality,
-        "name": name,
-    }
-    retval["metadata"] = metadata
-    retval["version"] = SCHEMA_VERSION
-    return retval
+    metadata: Dict[str, Optional[str]] = dict(id_column=id_column, modality=modality, name=name)
+    return Schema.create(metadata=metadata, fields=fields_dict, version=SCHEMA_VERSION)
 
 
-def construct_schema(
-    fields: List[str],
-    data_types: List[DataType],
-    feature_types: List[FeatureType],
-    id_column: str,
-    modality: Modality,
-    dataset_name: str,
-) -> Schema:
-    retval: Schema = {
-        "fields": {},
-        "metadata": {"id_column": id_column, "modality": modality, "name": dataset_name},
-        "version": SCHEMA_VERSION,
-    }
-    for field, data_type, feature_type in zip(fields, data_types, feature_types):
-        retval["fields"][field] = {"data_type": data_type, "feature_type": feature_type}
-    return retval
+# def construct_schema(
+#     fields: List[str],
+#     data_types: List[DataType],
+#     feature_types: List[FeatureType],
+#     id_column: str,
+#     modality: Modality,
+#     dataset_name: str,
+# ) -> Schema:
+#     field_dict = dict()
+#     for field, data_type, feature_type in zip(fields, data_types, feature_types):
+#         field_dict[field] = {"data_type": data_type, "feature_type": feature_type}
+#     retval = {
+#         "fields": field_dict,
+#         "metadata": {"id_column": id_column, "modality": modality, "name": dataset_name},
+#         "version": SCHEMA_VERSION,
+#     }
+#     return Schema.create(schema_dict=retval)
 
 
 def save_schema(schema: Schema, filename: Optional[str]) -> None:
@@ -424,7 +385,7 @@ def save_schema(schema: Schema, filename: Optional[str]) -> None:
         filename = "schema.json"
     if filename:
         progress(f"Writing schema to {filename}...")
-        dump_json(filename, schema)
+        dump_json(filename, schema.to_dict())
         success("Saved.")
     else:
         info("Schema was not saved.")

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -15,12 +15,9 @@ import semver
 from cleanlab_cli import MIN_SCHEMA_VERSION, SCHEMA_VERSION, MAX_SCHEMA_VERSION
 from cleanlab_cli.click_helpers import progress, success, info, abort
 from cleanlab_cli.dataset.schema_types import (
-    DATA_TYPES_TO_FEATURE_TYPES,
     FeatureType,
     Schema,
     DataType,
-    FieldSpecification,
-    SchemaMetadata,
 )
 from cleanlab_cli.types import Modality
 from cleanlab_cli.util import (
@@ -353,25 +350,6 @@ def propose_schema(
 
     metadata: Dict[str, Optional[str]] = dict(id_column=id_column, modality=modality, name=name)
     return Schema.create(metadata=metadata, fields=fields_dict, version=SCHEMA_VERSION)
-
-
-# def construct_schema(
-#     fields: List[str],
-#     data_types: List[DataType],
-#     feature_types: List[FeatureType],
-#     id_column: str,
-#     modality: Modality,
-#     dataset_name: str,
-# ) -> Schema:
-#     field_dict = dict()
-#     for field, data_type, feature_type in zip(fields, data_types, feature_types):
-#         field_dict[field] = {"data_type": data_type, "feature_type": feature_type}
-#     retval = {
-#         "fields": field_dict,
-#         "metadata": {"id_column": id_column, "modality": modality, "name": dataset_name},
-#         "version": SCHEMA_VERSION,
-#     }
-#     return Schema.create(schema_dict=retval)
 
 
 def save_schema(schema: Schema, filename: Optional[str]) -> None:

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -182,10 +182,14 @@ def is_filepath(string: str, check_existing: bool = False) -> bool:
     return pathlib.Path(string).suffix != "" and " " not in string
 
 
+def get_validation_sample_size(values):
+    return max(20, len(values))
+
+
 def _values_are_datetime(values: Collection[Any]) -> bool:
     try:
         # check for datetime first
-        val_sample = random.sample(list(values), 20)
+        val_sample = random.sample(list(values), get_validation_sample_size(20))
         for s in val_sample:
             res = pd.to_datetime(s)
             if res is NaT:
@@ -197,7 +201,7 @@ def _values_are_datetime(values: Collection[Any]) -> bool:
 
 def _values_are_integers(values: Collection[Any]) -> bool:
     try:
-        val_sample = random.sample(list(values), 20)
+        val_sample = random.sample(list(values), get_validation_sample_size(values))
         for s in val_sample:
             if str(int(s)) != s:
                 return False
@@ -208,11 +212,19 @@ def _values_are_integers(values: Collection[Any]) -> bool:
 
 def _values_are_floats(values: Collection[Any]) -> bool:
     try:
-        val_sample = random.sample(list(values), 20)
+        val_sample = random.sample(list(values), get_validation_sample_size(20))
         for s in val_sample:
             float(s)
     except Exception:
         return False
+    return True
+
+
+def _values_are_filepaths(values: Collection[Any]) -> bool:
+    val_sample = random.sample(list(values), 20)
+    for s in val_sample:
+        if not is_filepath(s):
+            return False
     return True
 
 
@@ -260,7 +272,7 @@ def infer_types(values: Collection[Any]) -> Tuple[DataType, FeatureType]:
             if multiple_separate_words_detected(values):
                 return "string", "text"
             else:
-                if all([is_filepath(s) for s in random.sample(list(values), 20)]):
+                if _values_are_filepaths(values):
                     return "string", "filepath"
                 return "string", "identifier"
         elif ratio_unique <= CATEGORICAL_RATIO_THRESHOLD:

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -149,7 +149,7 @@ def is_filepath(string: str, check_existing: bool = False) -> bool:
 
 
 def get_validation_sample_size(values: Sized) -> int:
-    return max(20, len(values))
+    return min(20, len(values))
 
 
 def _values_are_datetime(values: Collection[Any]) -> bool:

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -187,7 +187,7 @@ def _values_are_floats(values: Collection[Any]) -> bool:
 
 
 def _values_are_filepaths(values: Collection[Any]) -> bool:
-    val_sample = random.sample(list(values), 20)
+    val_sample = random.sample(list(values), get_validation_sample_size(values))
     for s in val_sample:
         if not is_filepath(s):
             return False

--- a/cleanlab_cli/dataset/schema_types.py
+++ b/cleanlab_cli/dataset/schema_types.py
@@ -114,11 +114,18 @@ class Schema:
             fields_[field] = FieldSpecification.create(
                 field_spec["data_type"], field_spec["feature_type"]
             )
+
+        # metadata variables
+        id_column = metadata["id_column"]
+        modality = metadata["modality"]
+        name = metadata["name"]
+        assert id_column is not None
+        assert modality is not None
+        assert name is not None
+        filepath_column: Optional[str] = metadata.get("filepath_column", None)
         return Schema(
             metadata=SchemaMetadata.create(
-                id_column=metadata["id_column"],
-                modality=metadata["modality"],
-                name=metadata["name"],
+                id_column=id_column, modality=modality, name=name, filepath_column=filepath_column
             ),
             fields=fields_,
             version=version,

--- a/cleanlab_cli/dataset/schema_types.py
+++ b/cleanlab_cli/dataset/schema_types.py
@@ -115,7 +115,11 @@ class Schema:
                 field_spec["data_type"], field_spec["feature_type"]
             )
         return Schema(
-            metadata=SchemaMetadata.create(*metadata),
+            metadata=SchemaMetadata.create(
+                id_column=metadata["id_column"],
+                modality=metadata["modality"],
+                name=metadata["name"],
+            ),
             fields=fields_,
             version=version,
         )

--- a/cleanlab_cli/dataset/schema_types.py
+++ b/cleanlab_cli/dataset/schema_types.py
@@ -6,7 +6,6 @@ from cleanlab_cli.types import Modality
 
 SchemaMetadataDictType = Dict[str, Optional[str]]
 SchemaFieldsDictType = Dict[str, Dict[str, str]]
-SchemaDictType = Dict[str, Union[str, SchemaMetadataDictType, SchemaFieldsDictType]]
 
 
 class DataType(Enum):
@@ -74,7 +73,7 @@ class SchemaMetadata:
 
     @staticmethod
     def create(
-        id_column: str, modality: str, name: str, filepath_column: Optional[str]
+        id_column: str, modality: str, name: str, filepath_column: Optional[str] = None
     ) -> "SchemaMetadata":
         return SchemaMetadata(
             id_column=id_column,

--- a/cleanlab_cli/dataset/schema_types.py
+++ b/cleanlab_cli/dataset/schema_types.py
@@ -1,15 +1,139 @@
-from typing import Dict, Set
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Set, Optional, Union, Any
 
-from cleanlab_cli.types import DataType, FeatureType
+from cleanlab_cli.types import Modality
+
+SchemaMetadataDictType = Dict[str, Optional[str]]
+SchemaFieldsDictType = Dict[str, Dict[str, str]]
+SchemaDictType = Dict[str, Union[str, SchemaMetadataDictType, SchemaFieldsDictType]]
+
+
+class DataType(Enum):
+    string = "string"
+    integer = "integer"
+    float = "float"
+    boolean = "boolean"
+
+
+class FeatureType(Enum):
+    identifier = "identifier"
+    categorical = "categorical"
+    numeric = "numeric"
+    text = "text"
+    boolean = "boolean"
+    datetime = "datetime"
+    filepath = "filepath"
+
 
 DATA_TYPES_TO_FEATURE_TYPES: Dict[DataType, Set[FeatureType]] = {
-    "string": {"text", "categorical", "datetime", "identifier"},
-    "integer": {"categorical", "datetime", "identifier", "numeric"},
-    "float": {"datetime", "numeric"},
-    "boolean": {"boolean"},
+    DataType.string: {
+        FeatureType.text,
+        FeatureType.categorical,
+        FeatureType.datetime,
+        FeatureType.identifier,
+    },
+    DataType.integer: {
+        FeatureType.categorical,
+        FeatureType.datetime,
+        FeatureType.identifier,
+        FeatureType.numeric,
+    },
+    DataType.float: {FeatureType.datetime, FeatureType.numeric},
+    DataType.boolean: {FeatureType.boolean},
 }
 
-PYTHON_TYPES_TO_READABLE_STRING: Dict[type, DataType] = {
+
+@dataclass
+class FieldSpecification:
+    data_type: DataType
+    feature_type: FeatureType
+
+    @staticmethod
+    def create(data_type: str, feature_type: str) -> "FieldSpecification":
+        data_type_ = DataType(data_type)
+        feature_type_ = FeatureType(feature_type)
+
+        if feature_type_ not in DATA_TYPES_TO_FEATURE_TYPES[data_type_]:
+            raise ValueError(
+                f"Invalid column feature type: '{feature_type_.value}' for data type: '{data_type_.value}'. "
+                f"Accepted categories for type '{data_type_.value}' are: {', '.join(t.value for t in DATA_TYPES_TO_FEATURE_TYPES[data_type_])}"
+            )
+        return FieldSpecification(data_type=data_type_, feature_type=feature_type_)
+
+    def to_dict(self) -> Dict[str, str]:
+        return dict(data_type=self.data_type.value, feature_type=self.feature_type.value)
+
+
+@dataclass
+class SchemaMetadata:
+    id_column: str
+    modality: Modality
+    name: str
+    filepath_column: Optional[str]
+
+    @staticmethod
+    def create(
+        id_column: str, modality: str, name: str, filepath_column: Optional[str]
+    ) -> "SchemaMetadata":
+        return SchemaMetadata(
+            id_column=id_column,
+            modality=Modality(modality),
+            name=name,
+            filepath_column=filepath_column,
+        )
+
+    def to_dict(self) -> SchemaMetadataDictType:
+        return dict(
+            id_column=self.id_column,
+            modality=self.modality.value,
+            name=self.name,
+            filepath_column=self.filepath_column,
+        )
+
+
+@dataclass
+class Schema:
+    metadata: SchemaMetadata
+    fields: Dict[str, FieldSpecification]
+    version: str
+
+    @staticmethod
+    def create(
+        metadata: SchemaMetadataDictType, fields: Dict[str, Dict[str, str]], version: str
+    ) -> "Schema":
+        fields_ = dict()
+        for field, field_spec in fields.items():
+            if not isinstance(field, str):
+                raise ValueError(
+                    f"All schema columns must be strings. Found non-string column: {field}"
+                )
+            if field == "":
+                raise ValueError(
+                    "Found empty string for schema column name. Schema columns cannot be empty strings."
+                )
+            fields_[field] = FieldSpecification.create(
+                field_spec["data_type"], field_spec["feature_type"]
+            )
+        return Schema(
+            metadata=SchemaMetadata.create(*metadata),
+            fields=fields_,
+            version=version,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        retval: Dict[str, Any] = dict()
+        retval["metadata"] = self.metadata.to_dict()
+        fields: Dict[str, Dict[str, str]] = dict()
+        for field, field_spec in self.fields.items():
+            fields[field] = field_spec.to_dict()
+        retval["fields"] = fields
+        retval["version"] = self.version
+
+        return retval
+
+
+PYTHON_TYPES_TO_READABLE_STRING: Dict[type, str] = {
     str: "string",
     float: "float",
     int: "integer",
@@ -17,8 +141,8 @@ PYTHON_TYPES_TO_READABLE_STRING: Dict[type, DataType] = {
 }
 
 DATA_TYPES_TO_PYTHON_TYPES: Dict[DataType, type] = {
-    "string": str,
-    "float": float,
-    "integer": int,
-    "boolean": bool,
+    DataType.string: str,
+    DataType.float: float,
+    DataType.integer: int,
+    DataType.boolean: bool,
 }

--- a/cleanlab_cli/dataset/upload.py
+++ b/cleanlab_cli/dataset/upload.py
@@ -17,7 +17,7 @@ from cleanlab_cli.dataset.upload_helpers import upload_dataset
 from cleanlab_cli.decorators import auth_config, previous_state
 from cleanlab_cli.decorators.auth_config import AuthConfig
 from cleanlab_cli.decorators.previous_state import PreviousState
-from cleanlab_cli.types import Schema, Modality, CommandState
+from cleanlab_cli.types import Schema, Modality, CommandState, MODALITIES
 from cleanlab_cli.util import init_dataset_from_filepath
 
 
@@ -77,8 +77,8 @@ def upload_with_schema(
 @click.option(
     "--modality",
     "-m",
-    type=click.Choice(["text", "tabular"]),
-    help="If uploading a new dataset without a schema, specify data modality: text, tabular",
+    type=click.Choice(MODALITIES),
+    help=f"If uploading a new dataset without a schema, specify data modality: {', '.join(MODALITIES)}",
 )
 @click.option(
     "--name",
@@ -181,8 +181,8 @@ def upload(
     ### Check that all required arguments are present
 
     if modality is None:
-        while modality not in ["text", "tabular"]:
-            modality = click.prompt("Specify your dataset modality (text, tabular)")
+        while modality not in MODALITIES:
+            modality = click.prompt(f"Specify your dataset modality ({', '.join(MODALITIES)})")
 
     if id_column is None:
         id_column_guess = _find_best_matching_column("id", columns)

--- a/cleanlab_cli/dataset/upload.py
+++ b/cleanlab_cli/dataset/upload.py
@@ -17,7 +17,7 @@ from cleanlab_cli.dataset.upload_helpers import upload_dataset
 from cleanlab_cli.decorators import auth_config, previous_state
 from cleanlab_cli.decorators.auth_config import AuthConfig
 from cleanlab_cli.decorators.previous_state import PreviousState
-from cleanlab_cli.types import Schema, Modality, CommandState, MODALITIES
+from cleanlab_cli.types import Modality, CommandState, MODALITIES
 from cleanlab_cli.util import init_dataset_from_filepath
 
 
@@ -101,7 +101,7 @@ def upload(
     id: Optional[str],
     schema: Optional[str],
     id_column: Optional[str],
-    modality: Optional[Modality],
+    modality: Optional[str],
     name: Optional[str],
     output: Optional[str],
     resume: Optional[bool],

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -47,19 +47,6 @@ from cleanlab_cli import click_helpers
 from cleanlab_cli.click_helpers import success, info, progress
 
 
-def warning_to_readable_name(warning: ValidationWarning) -> str:
-    return {
-        ValidationWarning.MISSING_ID: "Rows with missing IDs (rows are dropped)",
-        ValidationWarning.MISSING_VAL: "Rows with missing values (values replaced with null)",
-        ValidationWarning.TYPE_MISMATCH: (
-            "Rows with values that do not match the schema (values replaced with null)"
-        ),
-        ValidationWarning.DUPLICATE_ID: (
-            "Rows with duplicate IDs (only the first row instance is kept, all later rows dropped)"
-        ),
-    }[warning]
-
-
 def get_value_type(val: Any) -> str:
     for python_type, readable_string in PYTHON_TYPES_TO_READABLE_STRING.items():
         if isinstance(val, python_type):

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -26,7 +26,12 @@ from collections import defaultdict
 from sys import getsizeof
 from tqdm import tqdm
 from cleanlab_cli import api_service
-from cleanlab_cli.dataset.upload_types import ValidationWarning, WarningLog, RowWarningsType
+from cleanlab_cli.dataset.upload_types import (
+    ValidationWarning,
+    WarningLog,
+    RowWarningsType,
+    warning_to_readable_name,
+)
 from cleanlab_cli.types import (
     RecordType,
 )

--- a/cleanlab_cli/dataset/upload_types.py
+++ b/cleanlab_cli/dataset/upload_types.py
@@ -1,8 +1,8 @@
 from enum import Enum
-from typing import Dict, List, Union, Collection
+from typing import Dict, List, Collection
 from dataclasses import dataclass
 
-from cleanlab_cli.dataset import warning_to_readable_name
+from cleanlab_cli.dataset.upload_helpers import warning_to_readable_name
 
 
 class ValidationWarning(Enum):

--- a/cleanlab_cli/dataset/upload_types.py
+++ b/cleanlab_cli/dataset/upload_types.py
@@ -2,14 +2,25 @@ from enum import Enum
 from typing import Dict, List, Collection
 from dataclasses import dataclass
 
-from cleanlab_cli.dataset.upload_helpers import warning_to_readable_name
-
 
 class ValidationWarning(Enum):
     MISSING_ID = "MISSING_ID"
     MISSING_VAL = "MISSING_VAL"
     TYPE_MISMATCH = "TYPE_MISMATCH"
     DUPLICATE_ID = "DUPLICATE_ID"
+
+
+def warning_to_readable_name(warning: ValidationWarning) -> str:
+    return {
+        ValidationWarning.MISSING_ID: "Rows with missing IDs (rows are dropped)",
+        ValidationWarning.MISSING_VAL: "Rows with missing values (values replaced with null)",
+        ValidationWarning.TYPE_MISMATCH: (
+            "Rows with values that do not match the schema (values replaced with null)"
+        ),
+        ValidationWarning.DUPLICATE_ID: (
+            "Rows with duplicate IDs (only the first row instance is kept, all later rows dropped)"
+        ),
+    }[warning]
 
 
 RowWarningsType = Dict[ValidationWarning, List[str]]

--- a/cleanlab_cli/dataset/upload_types.py
+++ b/cleanlab_cli/dataset/upload_types.py
@@ -1,0 +1,44 @@
+from enum import Enum
+from typing import Dict, List, Union, Collection
+from dataclasses import dataclass
+
+from cleanlab_cli.dataset import warning_to_readable_name
+
+
+class ValidationWarning(Enum):
+    MISSING_ID = "MISSING_ID"
+    MISSING_VAL = "MISSING_VAL"
+    TYPE_MISMATCH = "TYPE_MISMATCH"
+    DUPLICATE_ID = "DUPLICATE_ID"
+
+
+RowWarningsType = Dict[ValidationWarning, List[str]]
+
+
+@dataclass
+class WarningLog:
+    MISSING_ID: List[str]
+    MISSING_VAL: Dict[str, List[str]]
+    TYPE_MISMATCH: Dict[str, List[str]]
+    DUPLICATE_ID: Dict[str, List[str]]
+
+    @staticmethod
+    def init() -> "WarningLog":
+        return WarningLog(
+            MISSING_ID=list(), MISSING_VAL=dict(), TYPE_MISMATCH=dict(), DUPLICATE_ID=dict()
+        )
+
+    def get(self, key: ValidationWarning) -> Collection[str]:
+        return {
+            ValidationWarning.MISSING_ID: self.MISSING_ID,
+            ValidationWarning.MISSING_VAL: self.MISSING_VAL,
+            ValidationWarning.TYPE_MISMATCH: self.TYPE_MISMATCH,
+            ValidationWarning.DUPLICATE_ID: self.DUPLICATE_ID,
+        }[key]
+
+    def to_dict(self, readable: bool = False) -> Dict[str, Collection[str]]:
+        retval = dict()
+        for warning_type in ValidationWarning:
+            key = warning_to_readable_name(warning_type) if readable else warning_type.value
+            retval[key] = self.get(warning_type)
+        return retval

--- a/cleanlab_cli/types.py
+++ b/cleanlab_cli/types.py
@@ -1,6 +1,5 @@
 from enum import Enum
-from typing import Dict, Any, Literal, Optional, Union, List
-from typing_extensions import NotRequired, TypedDict
+from typing import Dict, Any, Optional, Union, TypedDict
 
 JSONDict = Dict[str, Any]
 IDType = Union[str, int]

--- a/cleanlab_cli/types.py
+++ b/cleanlab_cli/types.py
@@ -1,10 +1,15 @@
 from enum import Enum
-from typing import Dict, Any, Literal, Optional, Union, List, TypedDict
+from typing import Dict, Any, Literal, Optional, Union, List
+from typing_extensions import NotRequired, TypedDict
 
 JSONDict = Dict[str, Any]
-Modality = Literal["text", "tabular"]
+Modality = Literal["text", "tabular", "image"]
+MODALITIES = ["text", "tabular", "image"]
 DataType = Literal["string", "integer", "float", "boolean"]
-FeatureType = Literal["identifier", "categorical", "numeric", "text", "boolean", "datetime"]
+DATATYPES = ["string", "integer", "float", "boolean"]
+FeatureType = Literal[
+    "identifier", "categorical", "numeric", "text", "boolean", "datetime", "filepath"
+]
 IDType = Union[str, int]
 ValidationWarningType = Literal["MISSING_ID", "MISSING_VAL", "TYPE_MISMATCH", "DUPLICATE_ID"]
 
@@ -44,6 +49,7 @@ class SchemaMetadata(TypedDict):
     id_column: str
     modality: Modality
     name: str
+    filepath: NotRequired[str]
 
 
 class Schema(TypedDict):

--- a/cleanlab_cli/types.py
+++ b/cleanlab_cli/types.py
@@ -3,22 +3,16 @@ from typing import Dict, Any, Literal, Optional, Union, List
 from typing_extensions import NotRequired, TypedDict
 
 JSONDict = Dict[str, Any]
-Modality = Literal["text", "tabular", "image"]
-MODALITIES = ["text", "tabular", "image"]
-DataType = Literal["string", "integer", "float", "boolean"]
-DATATYPES = ["string", "integer", "float", "boolean"]
-FeatureType = Literal[
-    "identifier", "categorical", "numeric", "text", "boolean", "datetime", "filepath"
-]
 IDType = Union[str, int]
-ValidationWarningType = Literal["MISSING_ID", "MISSING_VAL", "TYPE_MISMATCH", "DUPLICATE_ID"]
 
-VALIDATION_WARNING_TYPES: List[ValidationWarningType] = [
-    "MISSING_ID",
-    "MISSING_VAL",
-    "TYPE_MISMATCH",
-    "DUPLICATE_ID",
-]
+
+class Modality(Enum):
+    text = "text"
+    tabular = "tabular"
+    image = "image"
+
+
+MODALITIES = [m.value for m in Modality]
 
 
 class DatasetFileExtension(Enum):
@@ -29,33 +23,6 @@ class DatasetFileExtension(Enum):
 
 
 RecordType = Dict[str, Any]
-
-RowWarningsType = Dict[ValidationWarningType, List[str]]
-
-
-class WarningLogType(TypedDict):
-    MISSING_ID: List[str]
-    MISSING_VAL: Dict[str, List[str]]
-    TYPE_MISMATCH: Dict[str, List[str]]
-    DUPLICATE_ID: Dict[str, List[str]]
-
-
-class FieldSpecification(TypedDict):
-    data_type: DataType
-    feature_type: FeatureType
-
-
-class SchemaMetadata(TypedDict):
-    id_column: str
-    modality: Modality
-    name: str
-    filepath: NotRequired[str]
-
-
-class Schema(TypedDict):
-    metadata: SchemaMetadata
-    fields: Dict[str, FieldSpecification]
-    version: str
 
 
 class CommandState(TypedDict):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 black
 pre-commit
 twine
+mypy

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         "ijson>=3.1.4",
         "jsonstreams>=0.6.0",
         "semver>=2.13.0",
-        "typing-extensions>=4.3.0",
     ],
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "ijson>=3.1.4",
         "jsonstreams>=0.6.0",
         "semver>=2.13.0",
+        "typing-extensions>=4.3.0",
     ],
     entry_points="""
         [console_scripts]

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -1,3 +1,2 @@
 pytest
 pytest-benchmark
-types-requests


### PR DESCRIPTION
This PR improves on #37 by rewriting most of the `TypedDict` and `Literal` instances as `dataclass` and `Enum` instances respectively. 

This makes for some cleaner code:
- No more string literals, just enum values
- Simplified `validate_schema`, since the Dataclass and Enum types enforce that the schema contains all relevant keys and that Enum-casted values are valid

Also simplifies some typing issues going forward, as we would need `typing-extensions` for constructs like `NotRequired` for image modality-related schema changes.

PR also includes a few image modality related changes.