### PR TITLE
Partial image support and other small improvements

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -17,3 +17,6 @@ ignore_missing_imports = True
 
 [mypy-semver.*]
 ignore_missing_imports = True
+
+[mypy-PIL.*]
+ignore_missing_imports = True

--- a/cleanlab_cli/api_service.py
+++ b/cleanlab_cli/api_service.py
@@ -35,39 +35,22 @@ def handle_api_error_from_json(res_json: JSONDict, show_warning: bool = False) -
 
 
 def initialize_dataset(api_key: str, schema: Schema) -> str:
-    fields = list(schema.fields)
-    data_types = [spec.data_type.value for spec in schema.fields.values()]
-    feature_types = [spec.feature_type.value for spec in schema.fields.values()]
-    id_column = schema.metadata.id_column
-    modality = schema.metadata.modality.value
-    dataset_name = schema.metadata.name
-
-    res = requests.post(
-        base_url + "/datasets",
-        data={
-            "api_key": api_key,
-            "fields": json.dumps(fields),
-            "data_types": json.dumps(data_types),
-            "feature_types": json.dumps(feature_types),
-            "id_column": id_column,
-            "modality": modality,
-            "dataset_name": dataset_name,
-        },
-    )
+    request_json = dict(api_key=api_key, schema=schema.to_dict())
+    res = requests.post(base_url + "/datasets", json=request_json)
     handle_api_error(res)
     dataset_id: str = res.json()["dataset_id"]
     return dataset_id
 
 
 def get_existing_ids(api_key: str, dataset_id: str) -> List[IDType]:
-    res = requests.get(base_url + f"/datasets/{dataset_id}/ids", data=dict(api_key=api_key))
+    res = requests.get(base_url + f"/datasets/{dataset_id}/ids", json=dict(api_key=api_key))
     handle_api_error(res)
     existing_ids: List[IDType] = res.json()["existing_ids"]
     return existing_ids
 
 
 def get_dataset_schema(api_key: str, dataset_id: str) -> Schema:
-    res = requests.get(base_url + f"/datasets/{dataset_id}/schema", data=dict(api_key=api_key))
+    res = requests.get(base_url + f"/datasets/{dataset_id}/schema", json=dict(api_key=api_key))
     handle_api_error(res)
     schema: Schema = res.json()["schema"]
     return schema
@@ -106,7 +89,7 @@ def download_cleanlab_columns(api_key: str, cleanset_id: str, all: bool = False)
     :return: return (rows, id_column)
     """
     res = requests.get(
-        base_url + f"/cleansets/{cleanset_id}/columns?all={all}", data=dict(api_key=api_key)
+        base_url + f"/cleansets/{cleanset_id}/columns?all={all}", json=dict(api_key=api_key)
     )
     handle_api_error(res)
     rows: List[List[Any]] = res.json()["rows"]
@@ -114,33 +97,33 @@ def download_cleanlab_columns(api_key: str, cleanset_id: str, all: bool = False)
 
 
 def get_completion_status(api_key: str, dataset_id: str) -> bool:
-    res = requests.get(base_url + f"/datasets/{dataset_id}/complete", data=dict(api_key=api_key))
+    res = requests.get(base_url + f"/datasets/{dataset_id}/complete", json=dict(api_key=api_key))
     handle_api_error(res)
     completed: bool = res.json()["complete"]
     return completed
 
 
 def complete_upload(api_key: str, dataset_id: str) -> None:
-    res = requests.patch(base_url + f"/datasets/{dataset_id}/complete", data=dict(api_key=api_key))
+    res = requests.patch(base_url + f"/datasets/{dataset_id}/complete", json=dict(api_key=api_key))
     handle_api_error(res)
 
 
 def get_id_column(api_key: str, cleanset_id: str) -> str:
-    res = requests.get(base_url + f"/cleansets/{cleanset_id}/id_column", data=dict(api_key=api_key))
+    res = requests.get(base_url + f"/cleansets/{cleanset_id}/id_column", json=dict(api_key=api_key))
     handle_api_error(res)
     id_column: str = res.json()["id_column"]
     return id_column
 
 
 def validate_api_key(api_key: str) -> bool:
-    res = requests.get(base_url + "/validate", data=dict(api_key=api_key))
+    res = requests.get(base_url + "/validate", json=dict(api_key=api_key))
     handle_api_error(res)
     valid: bool = res.json()["valid"]
     return valid
 
 
 def check_client_version() -> bool:
-    res = requests.post(base_url + "/check_client_version", data=dict(version=__version__))
+    res = requests.post(base_url + "/check_client_version", json=dict(version=__version__))
     handle_api_error(res)
     valid: bool = res.json()["valid"]
     return valid
@@ -148,7 +131,7 @@ def check_client_version() -> bool:
 
 def check_dataset_limit(file_size: int, api_key: str, show_warning: bool = False) -> JSONDict:
     res = requests.post(
-        base_url + "/check_dataset_limit", data=dict(api_key=api_key, file_size=file_size)
+        base_url + "/check_dataset_limit", json=dict(api_key=api_key, file_size=file_size)
     )
     handle_api_error(res, show_warning=show_warning)
     res_json: JSONDict = res.json()

--- a/cleanlab_cli/cleanset/download.py
+++ b/cleanlab_cli/cleanset/download.py
@@ -8,6 +8,7 @@ import pandas as pd
 from cleanlab_cli import api_service
 from cleanlab_cli import click_helpers
 from cleanlab_cli import util
+from cleanlab_cli.cleanset.download_helpers import combine_fields_with_dataset
 from cleanlab_cli.click_helpers import log, progress
 from cleanlab_cli.decorators import previous_state, auth_config
 from cleanlab_cli.decorators.auth_config import AuthConfig
@@ -93,7 +94,7 @@ def download(
             fields_to_values = dict(row)
             ids_to_fields_to_values[str(row_id)] = fields_to_values
 
-        util.combine_fields_with_dataset(filepath, id_column, ids_to_fields_to_values, output)
+        combine_fields_with_dataset(filepath, id_column, ids_to_fields_to_values, output)
         click_helpers.success(f"Saved to {output}")
     else:
         while output is None or util.get_file_extension(output) != DatasetFileExtension.csv:

--- a/cleanlab_cli/cleanset/download.py
+++ b/cleanlab_cli/cleanset/download.py
@@ -97,7 +97,7 @@ def download(
         combine_fields_with_dataset(filepath, id_column, ids_to_fields_to_values, output)
         click_helpers.success(f"Saved to {output}")
     else:
-        while output is None or util.get_file_extension(output) != DatasetFileExtension.csv:
+        while output is None or util.get_dataset_file_extension(output) != DatasetFileExtension.csv:
             output = click.prompt(
                 "Specify your output filepath (must be .csv). Leave blank to use default",
                 default=f"clean_labels.csv",

--- a/cleanlab_cli/cleanset/download_helpers.py
+++ b/cleanlab_cli/cleanset/download_helpers.py
@@ -1,0 +1,36 @@
+import jsonstreams
+from typing import Dict
+
+from cleanlab_cli.types import RecordType, DatasetFileExtension
+from cleanlab_cli.util import get_file_extension, get_dataset_chunks, append_rows
+
+
+def combine_fields_with_dataset(
+    dataset_filepath: str,
+    id_column: str,
+    ids_to_fields_to_values: Dict[str, RecordType],
+    output_filepath: str,
+    num_rows_per_chunk: int = 10000,
+) -> None:
+    output_extension = get_file_extension(output_filepath)
+    if output_extension == DatasetFileExtension.json:
+        with jsonstreams.Stream(
+            jsonstreams.Type.OBJECT, filename=output_filepath, indent=True, pretty=True
+        ) as s:
+            with s.subarray("rows") as rows:
+                for chunk in get_dataset_chunks(
+                    dataset_filepath, id_column, ids_to_fields_to_values, num_rows_per_chunk
+                ):
+                    for row in chunk:
+                        rows.write(row)
+    elif output_extension in [
+        DatasetFileExtension.csv,
+        DatasetFileExtension.xls,
+        DatasetFileExtension.xlsx,
+    ]:
+        for chunk in get_dataset_chunks(
+            dataset_filepath, id_column, ids_to_fields_to_values, num_rows_per_chunk
+        ):
+            append_rows(chunk, output_filepath)
+    else:
+        raise ValueError(f"Invalid file type: {output_extension}.")

--- a/cleanlab_cli/cleanset/download_helpers.py
+++ b/cleanlab_cli/cleanset/download_helpers.py
@@ -2,7 +2,7 @@ import jsonstreams
 from typing import Dict
 
 from cleanlab_cli.types import RecordType, DatasetFileExtension
-from cleanlab_cli.util import get_file_extension, get_dataset_chunks, append_rows
+from cleanlab_cli.util import get_dataset_file_extension, get_dataset_chunks, append_rows
 
 
 def combine_fields_with_dataset(
@@ -12,7 +12,7 @@ def combine_fields_with_dataset(
     output_filepath: str,
     num_rows_per_chunk: int = 10000,
 ) -> None:
-    output_extension = get_file_extension(output_filepath)
+    output_extension = get_dataset_file_extension(output_filepath)
     if output_extension == DatasetFileExtension.json:
         with jsonstreams.Stream(
             jsonstreams.Type.OBJECT, filename=output_filepath, indent=True, pretty=True

--- a/cleanlab_cli/dataset/helpers.py
+++ b/cleanlab_cli/dataset/helpers.py
@@ -1,16 +1,6 @@
-from typing import Optional, List, Set, Any
+from typing import Optional, List
 
 import click
-from tqdm import tqdm
-import queue
-
-from cleanlab_cli.classes.dataset import Dataset
-from cleanlab_cli.dataset.upload_helpers import (
-    validate_and_process_record,
-    update_log_with_warnings,
-)
-from cleanlab_cli.dataset.schema_types import Schema
-from cleanlab_cli.dataset.upload_types import WarningLog
 from cleanlab_cli.dataset.schema_helpers import _find_best_matching_column
 
 
@@ -19,7 +9,7 @@ def get_id_column_if_undefined(id_column: Optional[str], columns: List[str]) -> 
         id_column_guess = _find_best_matching_column("id", columns)
         while id_column not in columns:
             id_column = click.prompt(
-                "Specify the name of the ID column in your dataset.", default=id_column_guess
+                "Specify the name of the ID column in your dataset", default=id_column_guess
             )
     return id_column
 
@@ -31,7 +21,7 @@ def get_filepath_column_if_undefined(
         filepath_column_guess = _find_best_matching_column("filepath", columns)
         while filepath_column not in columns:
             filepath_column = click.prompt(
-                f"Specify the name of the filepath column (containing your {modality} filepaths) in your dataset.",
+                f"Specify the name of the filepath column (containing your {modality} filepaths) in your dataset",
                 default=filepath_column_guess,
             )
     return filepath_column

--- a/cleanlab_cli/dataset/helpers.py
+++ b/cleanlab_cli/dataset/helpers.py
@@ -1,9 +1,17 @@
-from typing import Optional, List
+from typing import Optional, List, Set, Any
 
 import click
+from tqdm import tqdm
+import queue
 
+from cleanlab_cli.classes.dataset import Dataset
+from cleanlab_cli.dataset.upload_helpers import (
+    validate_and_process_record,
+    update_log_with_warnings,
+)
+from cleanlab_cli.dataset.schema_types import Schema
+from cleanlab_cli.dataset.upload_types import WarningLog
 from cleanlab_cli.dataset.schema_helpers import _find_best_matching_column
-from cleanlab_cli.types import Modality
 
 
 def get_id_column_if_undefined(id_column: Optional[str], columns: List[str]) -> str:

--- a/cleanlab_cli/dataset/helpers.py
+++ b/cleanlab_cli/dataset/helpers.py
@@ -1,0 +1,29 @@
+from typing import Optional, List
+
+import click
+
+from cleanlab_cli.dataset.schema_helpers import _find_best_matching_column
+from cleanlab_cli.types import Modality
+
+
+def get_id_column_if_undefined(id_column: Optional[str], columns: List[str]) -> str:
+    if id_column is None:
+        id_column_guess = _find_best_matching_column("id", columns)
+        while id_column not in columns:
+            id_column = click.prompt(
+                "Specify the name of the ID column in your dataset.", default=id_column_guess
+            )
+    return id_column
+
+
+def get_filepath_column_if_undefined(
+    modality: str, columns: List[str], filepath_column: Optional[str]
+) -> str:
+    if filepath_column is None:
+        filepath_column_guess = _find_best_matching_column("filepath", columns)
+        while filepath_column not in columns:
+            filepath_column = click.prompt(
+                f"Specify the name of the filepath column (containing your {modality} filepaths) in your dataset.",
+                default=filepath_column_guess,
+            )
+    return filepath_column

--- a/cleanlab_cli/dataset/image_utils.py
+++ b/cleanlab_cli/dataset/image_utils.py
@@ -2,7 +2,7 @@ from cleanlab_cli.types import ImageFileExtension
 from PIL import Image
 
 
-def is_valid_image(filepath):
+def is_valid_image(filepath: str) -> bool:
     """
     valid == has extension .jpeg or .png and image file can be opened by Pillow
     :param filepath:

--- a/cleanlab_cli/dataset/image_utils.py
+++ b/cleanlab_cli/dataset/image_utils.py
@@ -1,0 +1,18 @@
+from cleanlab_cli.types import ImageFileExtension
+from PIL import Image
+
+
+def is_valid_image(filepath):
+    """
+    valid == has extension .jpeg or .png and image file can be opened by Pillow
+    :param filepath:
+    :return:
+    """
+    try:
+        ImageFileExtension(filepath)
+        Image.open(filepath)
+    except ValueError:
+        return False
+    except IOError:
+        return False
+    return True

--- a/cleanlab_cli/dataset/schema.py
+++ b/cleanlab_cli/dataset/schema.py
@@ -118,7 +118,6 @@ def check_dataset_command(
 @click.option(
     "--id-column",
     type=str,
-    prompt=True,
     help="Name of ID column in the dataset",
 )
 @click.option(

--- a/cleanlab_cli/dataset/schema.py
+++ b/cleanlab_cli/dataset/schema.py
@@ -12,7 +12,6 @@ from cleanlab_cli.dataset.schema_helpers import (
     validate_schema,
     propose_schema,
     save_schema,
-    _find_best_matching_column,
 )
 from cleanlab_cli.dataset import upload_helpers
 from cleanlab_cli.decorators.previous_state import PreviousState
@@ -23,7 +22,6 @@ from cleanlab_cli.decorators import previous_state
 import json
 from cleanlab_cli.click_helpers import abort, info, success
 from cleanlab_cli import click_helpers
-from tqdm import tqdm
 
 
 @click.group(help="generate and validate dataset schema, or check your dataset against a schema")

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -65,7 +65,6 @@ def load_schema(filepath: str) -> Schema:
 
 def validate_schema(schema: Schema, columns: Collection[str]) -> None:
     """
-
     Checks that:
     (1) all schema column names are strings
     (2) all schema columns exist in the dataset columns
@@ -266,6 +265,7 @@ def propose_schema(
     columns: Optional[Collection[str]] = None,
     id_column: Optional[str] = None,
     modality: Optional[str] = None,
+    filepath_column: Optional[str] = None,
     name: Optional[str] = None,
     sample_size: int = 10000,
     max_rows_checked: int = 200000,

--- a/cleanlab_cli/dataset/schema_helpers.py
+++ b/cleanlab_cli/dataset/schema_helpers.py
@@ -31,12 +31,14 @@ def _find_best_matching_column(target_column: str, columns: List[str]) -> Option
     """
     Find the column from `columns` that is the closest match to the `target_col`.
     If no columns are likely, pick the first column of `columns`
+    If no columns are provided, return None
 
     :param target_column: some reserved column name, typically: 'id', 'label', or 'text'
     :param columns: non-empty list of column names
     :return:
     """
-    assert len(columns) > 0, "list of columns is empty"
+    if len(columns) == 0:
+        return None
     poss = []
     for c in columns:
         if c.lower() == target_column:
@@ -279,6 +281,7 @@ def propose_schema(
     :param columns: columns to generate a schema for
     :param id_column: ID column name
     :param name: name of dataset
+    :param filepath_column: filepath column name, i.e. name of column holding media filepaths (needed if modality is image)
     :param modality: data modality
     :param sample_size: default of 1000
     :param max_rows_checked: max rows to sample from
@@ -350,7 +353,9 @@ def propose_schema(
 
     assert id_column is not None
 
-    metadata: Dict[str, Optional[str]] = dict(id_column=id_column, modality=modality, name=name)
+    metadata: Dict[str, Optional[str]] = dict(
+        id_column=id_column, modality=modality, name=name, filepath_column=filepath_column
+    )
     return Schema.create(metadata=metadata, fields=fields_dict, version=SCHEMA_VERSION)
 
 

--- a/cleanlab_cli/dataset/schema_types.py
+++ b/cleanlab_cli/dataset/schema_types.py
@@ -31,6 +31,7 @@ DATA_TYPES_TO_FEATURE_TYPES: Dict[DataType, Set[FeatureType]] = {
         FeatureType.categorical,
         FeatureType.datetime,
         FeatureType.identifier,
+        FeatureType.filepath,
     },
     DataType.integer: {
         FeatureType.categorical,

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -319,7 +319,7 @@ async def upload_rows(
         await asyncio.gather(*upload_tasks)
 
 
-def check_filepath_column(modality: Modality, dataset_filepath: str, filepath_column: str):
+def check_filepath_column(modality: Modality, dataset_filepath: str, filepath_column: str) -> None:
     """
     Check the filepath column of a dataset to see if any of the filepaths are invalid.
     If >0 filepaths are invalid, print the number of invalid filepaths and prompt user for confirmation about
@@ -383,7 +383,8 @@ def upload_dataset(
     file_size = get_file_size(filepath)
     api_service.check_dataset_limit(file_size, api_key=api_key, show_warning=False)
 
-    if schema.metadata.modality == Modality.image.value:
+    if schema.metadata.modality == Modality.image:
+        assert schema.metadata.filepath_column is not None
         check_filepath_column(
             modality=schema.metadata.modality,
             dataset_filepath=filepath,

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -344,25 +344,25 @@ def check_filepath_column(modality: Modality, dataset_filepath: str, filepath_co
         raise ValueError(
             f"No filepath column '{filepath_column}' found in dataset at {dataset_filepath}."
         )
-    invalid_filepaths = []
+    nonexistent_filepaths = []
     for record in dataset.read_streaming_records():
         filepath_value = record[filepath_column]
         if not os.path.exists(filepath_value):
-            invalid_filepaths.append(filepath_value)
+            nonexistent_filepaths.append(filepath_value)
 
-    num_invalid_filepaths = len(invalid_filepaths)
-    if num_invalid_filepaths > 0:
+    num_nonexistent_filepaths = len(nonexistent_filepaths)
+    if num_nonexistent_filepaths > 0:
         click.echo(
-            f"Found {num_invalid_filepaths} invalid filepaths in specified filepath column: {filepath_column}. "
-            f"As this is a {modality.value} dataset, these {num_invalid_filepaths} rows will be skipped unless the filepaths are fixed. "
-            f""
+            f"Found {num_nonexistent_filepaths} non-existent filepaths in specified filepath column: {filepath_column}. "
+            f"As this is a {modality.value} dataset, these {num_nonexistent_filepaths} rows will be skipped unless the filepaths are fixed. "
+            f"Filepaths must be absolute or relative to your current working directory: {os.getcwd()}"
         )
         to_print = click.confirm(
-            f"Would you like to print the {num_invalid_filepaths} filepaths to console?"
+            f"Would you like to print the {num_nonexistent_filepaths} filepaths to console?"
         )
         if to_print:
             click.echo("Invalid filepaths:\n")
-            click.echo(", ".join(invalid_filepaths))
+            click.echo(", ".join(nonexistent_filepaths))
 
         continue_with_upload = click.confirm(
             "Would you like to proceed with dataset upload? Rows with invalid filepaths will be skipped."

--- a/cleanlab_cli/dataset/upload_types.py
+++ b/cleanlab_cli/dataset/upload_types.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 class ValidationWarning(Enum):
     MISSING_ID = "MISSING_ID"
     MISSING_VAL = "MISSING_VAL"
+    MISSING_FILE = "MISSING_FILE"
     TYPE_MISMATCH = "TYPE_MISMATCH"
     DUPLICATE_ID = "DUPLICATE_ID"
 
@@ -13,6 +14,7 @@ class ValidationWarning(Enum):
 def warning_to_readable_name(warning: ValidationWarning) -> str:
     return {
         ValidationWarning.MISSING_ID: "Rows with missing IDs (rows are dropped)",
+        ValidationWarning.MISSING_FILE: "Rows with non-existent filepaths (rows are dropped)",
         ValidationWarning.MISSING_VAL: "Rows with missing values (values replaced with null)",
         ValidationWarning.TYPE_MISMATCH: (
             "Rows with values that do not match the schema (values replaced with null)"
@@ -30,19 +32,25 @@ RowWarningsType = Dict[ValidationWarning, List[str]]
 class WarningLog:
     MISSING_ID: List[str]
     MISSING_VAL: Dict[str, List[str]]
+    MISSING_FILE: Dict[str, List[str]]
     TYPE_MISMATCH: Dict[str, List[str]]
     DUPLICATE_ID: Dict[str, List[str]]
 
     @staticmethod
     def init() -> "WarningLog":
         return WarningLog(
-            MISSING_ID=list(), MISSING_VAL=dict(), TYPE_MISMATCH=dict(), DUPLICATE_ID=dict()
+            MISSING_ID=list(),
+            MISSING_VAL=dict(),
+            MISSING_FILE=dict(),
+            TYPE_MISMATCH=dict(),
+            DUPLICATE_ID=dict(),
         )
 
     def get(self, key: ValidationWarning) -> Collection[str]:
         return {
             ValidationWarning.MISSING_ID: self.MISSING_ID,
             ValidationWarning.MISSING_VAL: self.MISSING_VAL,
+            ValidationWarning.MISSING_FILE: self.MISSING_FILE,
             ValidationWarning.TYPE_MISMATCH: self.TYPE_MISMATCH,
             ValidationWarning.DUPLICATE_ID: self.DUPLICATE_ID,
         }[key]

--- a/cleanlab_cli/dataset/upload_types.py
+++ b/cleanlab_cli/dataset/upload_types.py
@@ -7,6 +7,7 @@ class ValidationWarning(Enum):
     MISSING_ID = "MISSING_ID"
     MISSING_VAL = "MISSING_VAL"
     MISSING_FILE = "MISSING_FILE"
+    INVALID_FILE = "INVALID_FILE"
     TYPE_MISMATCH = "TYPE_MISMATCH"
     DUPLICATE_ID = "DUPLICATE_ID"
 
@@ -16,6 +17,7 @@ def warning_to_readable_name(warning: ValidationWarning) -> str:
         ValidationWarning.MISSING_ID: "Rows with missing IDs (rows are dropped)",
         ValidationWarning.MISSING_FILE: "Rows with non-existent filepaths (rows are dropped)",
         ValidationWarning.MISSING_VAL: "Rows with missing values (values replaced with null)",
+        ValidationWarning.INVALID_FILE: "Rows with invalid files (rows are dropped)",
         ValidationWarning.TYPE_MISMATCH: (
             "Rows with values that do not match the schema (values replaced with null)"
         ),
@@ -33,6 +35,7 @@ class WarningLog:
     MISSING_ID: List[str]
     MISSING_VAL: Dict[str, List[str]]
     MISSING_FILE: Dict[str, List[str]]
+    INVALID_FILE: Dict[str, List[str]]
     TYPE_MISMATCH: Dict[str, List[str]]
     DUPLICATE_ID: Dict[str, List[str]]
 
@@ -42,6 +45,7 @@ class WarningLog:
             MISSING_ID=list(),
             MISSING_VAL=dict(),
             MISSING_FILE=dict(),
+            INVALID_FILE=dict(),
             TYPE_MISMATCH=dict(),
             DUPLICATE_ID=dict(),
         )
@@ -51,6 +55,7 @@ class WarningLog:
             ValidationWarning.MISSING_ID: self.MISSING_ID,
             ValidationWarning.MISSING_VAL: self.MISSING_VAL,
             ValidationWarning.MISSING_FILE: self.MISSING_FILE,
+            ValidationWarning.INVALID_FILE: self.INVALID_FILE,
             ValidationWarning.TYPE_MISMATCH: self.TYPE_MISMATCH,
             ValidationWarning.DUPLICATE_ID: self.DUPLICATE_ID,
         }[key]

--- a/cleanlab_cli/types.py
+++ b/cleanlab_cli/types.py
@@ -21,6 +21,11 @@ class DatasetFileExtension(Enum):
     json = ".json"
 
 
+class ImageFileExtension(Enum):
+    jpeg = ".jpeg"
+    png = ".png"
+
+
 RecordType = Dict[str, Any]
 
 

--- a/cleanlab_cli/util.py
+++ b/cleanlab_cli/util.py
@@ -4,7 +4,6 @@ Contains utility functions for interacting with dataset files
 import json
 import os
 import pathlib
-import jsonstreams
 import pandas as pd
 from typing import Optional, Dict, Any, List, Generator
 
@@ -101,34 +100,3 @@ def get_dataset_chunks(
 
     if chunk:
         yield chunk
-
-
-def combine_fields_with_dataset(
-    dataset_filepath: str,
-    id_column: str,
-    ids_to_fields_to_values: Dict[str, RecordType],
-    output_filepath: str,
-    num_rows_per_chunk: int = 10000,
-) -> None:
-    output_extension = get_file_extension(output_filepath)
-    if output_extension == DatasetFileExtension.json:
-        with jsonstreams.Stream(
-            jsonstreams.Type.OBJECT, filename=output_filepath, indent=True, pretty=True
-        ) as s:
-            with s.subarray("rows") as rows:
-                for chunk in get_dataset_chunks(
-                    dataset_filepath, id_column, ids_to_fields_to_values, num_rows_per_chunk
-                ):
-                    for row in chunk:
-                        rows.write(row)
-    elif output_extension in [
-        DatasetFileExtension.csv,
-        DatasetFileExtension.xls,
-        DatasetFileExtension.xlsx,
-    ]:
-        for chunk in get_dataset_chunks(
-            dataset_filepath, id_column, ids_to_fields_to_values, num_rows_per_chunk
-        ):
-            append_rows(chunk, output_filepath)
-    else:
-        raise ValueError(f"Invalid file type: {output_extension}.")

--- a/cleanlab_cli/util.py
+++ b/cleanlab_cli/util.py
@@ -12,12 +12,18 @@ from cleanlab_cli.classes.dataset import Dataset
 from cleanlab_cli.types import (
     RecordType,
     DatasetFileExtension,
+    ImageFileExtension,
 )
 
 
-def get_file_extension(filename: str) -> DatasetFileExtension:
+def get_dataset_file_extension(filename: str) -> DatasetFileExtension:
     file_extension = pathlib.Path(filename).suffix
     return DatasetFileExtension(file_extension)
+
+
+def get_image_file_extension(filename: str) -> ImageFileExtension:
+    file_extension = pathlib.Path(filename).suffix
+    return ImageFileExtension(file_extension)
 
 
 def get_filename(filepath: str) -> str:
@@ -29,7 +35,7 @@ def get_file_size(filepath: str) -> int:
 
 
 def read_file_as_df(filepath: str) -> pd.DataFrame:
-    ext = get_file_extension(filepath)
+    ext = get_dataset_file_extension(filepath)
     if ext == DatasetFileExtension.json:
         df = pd.read_json(filepath, convert_axes=False, convert_dates=False).T
         df.index = df.index.astype("str")
@@ -48,7 +54,7 @@ def is_null_value(val: str) -> bool:
 
 
 def init_dataset_from_filepath(filepath: str) -> Dataset:
-    ext = get_file_extension(filepath)
+    ext = get_dataset_file_extension(filepath)
     if ext == DatasetFileExtension.csv:
         return CsvDataset(filepath)
     elif ext == DatasetFileExtension.xls or ext == DatasetFileExtension.xlsx:
@@ -64,7 +70,7 @@ def dump_json(filepath: str, obj: object) -> None:
 
 def append_rows(rows: List[RecordType], filename: str) -> None:
     df = pd.DataFrame(rows)
-    ext = get_file_extension(filename)
+    ext = get_dataset_file_extension(filename)
     if ext == DatasetFileExtension.csv:
         if not os.path.exists(filename):
             df.to_csv(filename, mode="w", index=False, header=True)

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "ijson>=3.1.4",
         "jsonstreams>=0.6.0",
         "semver>=2.13.0",
+        "Pillow>=9.2.0",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
This PR introduces:
- Schema generation for image datasets
- Upload checks for image datasets, except for the actual images themselves getting uploaded (pending Studio backend changes)
- `filepath_column` is now an optional field for Schema metadata, meant to specify the column holding image (or media) filepaths
- New `ValidationWarning`s: `MISSING_FILE` and `INVALID_FILE`
- Switches to POST requests with JSON instead of Form data
- Small improvements to existing behavior + bug fixes

Merging in these changes first so that we can release an alpha package version for backend to use and incorporate.