### PR TITLE
Remaining image support changes

### DIFF
--- a/cleanlab_cli/api_service.py
+++ b/cleanlab_cli/api_service.py
@@ -84,12 +84,12 @@ async def upload_rows_async(
     schema: Schema,
     rows: List[Any],
 ) -> None:
-    modality = Schema.metadata.modality
+    modality = schema.metadata.modality
     needs_media_upload = modality in [Modality.image]
     columns = list(schema.fields.keys())
 
     if needs_media_upload:
-        filepath_column = Schema.metadata.filepath_column
+        filepath_column = schema.metadata.filepath_column
         assert filepath_column is not None
         filepath_column_idx = columns.index(filepath_column)
         filepaths = [get_image_filepath(row[filepath_column_idx], dataset_filepath) for row in rows]

--- a/cleanlab_cli/api_service.py
+++ b/cleanlab_cli/api_service.py
@@ -12,6 +12,7 @@ import aiohttp
 import requests
 
 from cleanlab_cli.click_helpers import abort, warn
+from cleanlab_cli.dataset.image_utils import get_image_filepath
 from cleanlab_cli.dataset.schema_types import Schema
 from cleanlab_cli import __version__
 from cleanlab_cli.types import JSONDict, IDType, Modality
@@ -79,6 +80,7 @@ async def upload_rows_async(
     session: aiohttp.ClientSession,
     api_key: str,
     dataset_id: str,
+    dataset_filepath: str,
     schema: Schema,
     rows: List[Any],
 ) -> None:
@@ -90,7 +92,7 @@ async def upload_rows_async(
         filepath_column = Schema.metadata.filepath_column
         assert filepath_column is not None
         filepath_column_idx = columns.index(filepath_column)
-        filepaths = [row[filepath_column_idx] for row in rows]
+        filepaths = [get_image_filepath(row[filepath_column_idx], dataset_filepath) for row in rows]
 
         filepath_to_post = get_presigned_posts(
             api_key=api_key, dataset_id=dataset_id, filepaths=filepaths, media_type=modality.value

--- a/cleanlab_cli/api_service.py
+++ b/cleanlab_cli/api_service.py
@@ -14,7 +14,7 @@ import requests
 from cleanlab_cli.click_helpers import abort, warn
 from cleanlab_cli.dataset.schema_types import Schema
 from cleanlab_cli import __version__
-from cleanlab_cli.types import JSONDict, IDType
+from cleanlab_cli.types import JSONDict, IDType, Modality
 
 base_url = os.environ.get("CLEANLAB_API_BASE_URL", "https://api.cleanlab.ai/api/cli/v0")
 
@@ -79,12 +79,32 @@ async def upload_rows_async(
     session: aiohttp.ClientSession,
     api_key: str,
     dataset_id: str,
+    schema: Schema,
     rows: List[Any],
-    columns_json: str,
 ) -> None:
+    modality = Schema.metadata.modality
+    needs_media_upload = modality in [Modality.image]
+    columns = list(schema.fields.keys())
+    filepath_column = Schema.metadata.filepath_column
+    filepath_column_idx = columns.index(filepath_column)
+
+    if needs_media_upload:
+        filepaths = [row[filepath_column_idx] for row in rows]
+
+        presigned_posts = get_presigned_posts(
+            api_key=api_key, dataset_id=dataset_id, filepaths=filepaths, media_type=modality.value
+        )
+
+        for filepath, presigned_post in zip(filepaths, presigned_posts):
+            await session.post(
+                url=presigned_post["url"],
+                data=presigned_post["fields"],
+                files={"file": open(filepath, "rb")},
+            )
+
     url = base_url + f"/datasets/{dataset_id}"
     data = gzip.compress(
-        json.dumps(dict(rows=json.dumps(rows), columns=columns_json)).encode("utf-8")
+        json.dumps(dict(rows=json.dumps(rows), columns=json.dumps(columns))).encode("utf-8")
     )
     headers = _construct_headers(api_key)
     headers["Content-Encoding"] = "gzip"
@@ -163,5 +183,18 @@ def check_dataset_limit(api_key: str, file_size: int, show_warning: bool = False
         headers=_construct_headers(api_key),
     )
     handle_api_error(res, show_warning=show_warning)
+    res_json: JSONDict = res.json()
+    return res_json
+
+
+def get_presigned_posts(
+    api_key: str, dataset_id: str, filepaths: List[str], media_type: str
+) -> JSONDict:
+    res = requests.get(
+        base_url + "/media_upload/presigned_posts",
+        json=dict(dataset_id=dataset_id, filepaths=filepaths, type=media_type),
+        headers=_construct_headers(api_key),
+    )
+    handle_api_error(res)
     res_json: JSONDict = res.json()
     return res_json

--- a/cleanlab_cli/dataset/image_utils.py
+++ b/cleanlab_cli/dataset/image_utils.py
@@ -1,5 +1,18 @@
+import os.path
+
 from cleanlab_cli.types import ImageFileExtension
 from PIL import Image
+from pathlib import Path
+
+
+def image_file_exists(image_filepath: str, dataset_filepath: str) -> bool:
+    if os.path.isabs(image_filepath):
+        return os.path.exists(image_filepath)
+    else:
+        dataset_path = Path(dataset_filepath)
+        directory_path = dataset_path.parent.absolute()
+        abs_image_filepath = os.path.join(directory_path, image_filepath)
+        return os.path.exists(abs_image_filepath)
 
 
 def is_valid_image(filepath: str) -> bool:

--- a/cleanlab_cli/dataset/image_utils.py
+++ b/cleanlab_cli/dataset/image_utils.py
@@ -18,9 +18,9 @@ def image_file_exists(image_filepath: str, dataset_filepath: str) -> bool:
     return os.path.exists(get_image_filepath(image_filepath, dataset_filepath))
 
 
-def is_valid_image(image_filepath: str, dataset_filepath: str) -> bool:
+def image_file_readable(image_filepath: str, dataset_filepath: str) -> bool:
     """
-    valid == has extension .jpeg or .png and image file can be opened by Pillow
+    readable == has extension .jpeg or .png and image file can be opened by Pillow
     """
     try:
         image_filepath = get_image_filepath(image_filepath, dataset_filepath)

--- a/cleanlab_cli/dataset/image_utils.py
+++ b/cleanlab_cli/dataset/image_utils.py
@@ -5,25 +5,27 @@ from PIL import Image
 from pathlib import Path
 
 
-def image_file_exists(image_filepath: str, dataset_filepath: str) -> bool:
+def get_image_filepath(image_filepath: str, dataset_filepath: str) -> str:
     if os.path.isabs(image_filepath):
-        return os.path.exists(image_filepath)
+        return image_filepath
     else:
         dataset_path = Path(dataset_filepath)
         directory_path = dataset_path.parent.absolute()
-        abs_image_filepath = os.path.join(directory_path, image_filepath)
-        return os.path.exists(abs_image_filepath)
+        return os.path.join(directory_path, image_filepath)
 
 
-def is_valid_image(filepath: str) -> bool:
+def image_file_exists(image_filepath: str, dataset_filepath: str) -> bool:
+    return os.path.exists(get_image_filepath(image_filepath, dataset_filepath))
+
+
+def is_valid_image(image_filepath: str, dataset_filepath: str) -> bool:
     """
     valid == has extension .jpeg or .png and image file can be opened by Pillow
-    :param filepath:
-    :return:
     """
     try:
-        ImageFileExtension(filepath)
-        Image.open(filepath)
+        image_filepath = get_image_filepath(image_filepath, dataset_filepath)
+        ImageFileExtension(image_filepath)
+        Image.open(image_filepath)
     except ValueError:
         return False
     except IOError:

--- a/cleanlab_cli/dataset/image_utils.py
+++ b/cleanlab_cli/dataset/image_utils.py
@@ -4,6 +4,8 @@ from cleanlab_cli.types import ImageFileExtension
 from PIL import Image
 from pathlib import Path
 
+from cleanlab_cli.util import get_image_file_extension
+
 
 def get_image_filepath(image_filepath: str, dataset_filepath: str) -> str:
     if os.path.isabs(image_filepath):
@@ -24,7 +26,7 @@ def image_file_readable(image_filepath: str, dataset_filepath: str) -> bool:
     """
     try:
         image_filepath = get_image_filepath(image_filepath, dataset_filepath)
-        ImageFileExtension(image_filepath)
+        get_image_file_extension(image_filepath)
         Image.open(image_filepath)
     except ValueError:
         return False

--- a/cleanlab_cli/dataset/image_utils.py
+++ b/cleanlab_cli/dataset/image_utils.py
@@ -26,7 +26,7 @@ def image_file_readable(image_filepath: str, dataset_filepath: str) -> bool:
     """
     try:
         image_filepath = get_image_filepath(image_filepath, dataset_filepath)
-        get_image_file_extension(image_filepath)
+        get_image_file_extension(image_filepath)  # throws an error if extension is not recognized
         Image.open(image_filepath)
     except ValueError:
         return False

--- a/cleanlab_cli/dataset/schema.py
+++ b/cleanlab_cli/dataset/schema.py
@@ -105,7 +105,7 @@ def check_dataset_command(
             upload_helpers.save_warning_log(log, output)
             click_helpers.confirm_open_file("Open your issues file for viewing?", filepath=output)
 
-    click.secho("Check completed.", fg="green")
+    click_helpers.success("Check completed.")
 
 
 @schema.command(name="generate", help="generate a schema based on your dataset")

--- a/cleanlab_cli/dataset/schema.py
+++ b/cleanlab_cli/dataset/schema.py
@@ -93,7 +93,7 @@ def check_dataset_command(
 
         if not output:
             output = click_helpers.confirm_save_prompt_filepath(
-                save_message="Would you like to save the issues for viewing?",
+                save_message="Save the issues for viewing?",
                 save_default=None,
                 prompt_message=(
                     "Specify a filename for the dataset issues. Leave this blank to use default"
@@ -103,9 +103,7 @@ def check_dataset_command(
             )
         if output:
             upload_helpers.save_warning_log(log, output)
-            click_helpers.confirm_open_file(
-                "Would you like to open your issues file for viewing?", filepath=output
-            )
+            click_helpers.confirm_open_file("Open your issues file for viewing?", filepath=output)
 
     click.secho("Check completed.", fg="green")
 
@@ -181,7 +179,7 @@ def generate_schema_command(
 
     if not output:
         output = click_helpers.confirm_save_prompt_filepath(
-            save_message="Would you like to save the generated schema?",
+            save_message="Save the generated schema?",
             save_default=None,
             prompt_message="Specify a filename for the schema. Leave this blank to use default",
             prompt_default="schema.json",
@@ -191,6 +189,4 @@ def generate_schema_command(
             return
 
     save_schema(proposed_schema, output)
-    click_helpers.confirm_open_file(
-        message="Would you like to open your schema file?", filepath=output
-    )
+    click_helpers.confirm_open_file(message="Open your schema file?", filepath=output)

--- a/cleanlab_cli/dataset/upload.py
+++ b/cleanlab_cli/dataset/upload.py
@@ -222,7 +222,7 @@ def upload(
         )
 
     save_filepath = click_helpers.confirm_save_prompt_filepath(
-        save_message="Would you like to save the generated schema?",
+        save_message="Save the generated schema?",
         save_default=None,
         prompt_message="Specify a filename for the schema. Leave this blank to use default",
         prompt_default="schema.json",

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -149,16 +149,16 @@ def validate_and_process_record(
                 if schema.metadata.modality == Modality.image:
                     if not image_file_exists(column_value, dataset_filepath):
                         msg, warn_type = (
-                            f"{column_name}: expected filepath but unable to find file at specified filepath {column_value}. "
+                            f"{column_name}: unable to find file at specified filepath {column_value}. "
                             f"Filepath must be absolute or relative to the directory containing your dataset file.",
                             ValidationWarning.MISSING_FILE,
                         )
                         warnings[warn_type].append(msg)
                         return None, row_id, warnings
                     else:
-                        if not is_valid_image(column_value):  # TODO validity check
+                        if not is_valid_image(column_value, dataset_filepath):
                             msg, warn_type = (
-                                f"{column_name}: could not open invalid file at {column_value}.",
+                                f"{column_name}: could not open file at {column_value}.",
                                 ValidationWarning.INVALID_FILE,
                             )
                             warnings[warn_type].append(msg)

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -281,7 +281,6 @@ async def upload_rows(
     api_key: str,
     dataset_id: str,
     schema: Schema,
-    columns: List[str],
     upload_queue: "queue.Queue[Optional[List[Any]]]",
     rows_per_payload: int,
 ) -> None:

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -356,15 +356,15 @@ def check_filepath_column(modality: Modality, dataset_filepath: str, filepath_co
     nonexistent_filepaths = []
     for record in dataset.read_streaming_records():
         filepath_value = record[filepath_column]
-        if not os.path.exists(filepath_value):
+        if not image_file_exists(filepath_value, dataset_filepath):
             nonexistent_filepaths.append(filepath_value)
 
     num_nonexistent_filepaths = len(nonexistent_filepaths)
     if num_nonexistent_filepaths > 0:
         click.echo(
-            f"Found {num_nonexistent_filepaths} non-existent filepaths in specified filepath column: {filepath_column}. "
-            f"As this is a {modality.value} dataset, these {num_nonexistent_filepaths} rows will be skipped unless the filepaths are fixed. "
-            f"Filepaths must be absolute or relative to your current working directory: {os.getcwd()}"
+            f"Found {num_nonexistent_filepaths} non-existent filepaths in specified {modality.value} filepath column: {filepath_column}.\n"
+            f"These {num_nonexistent_filepaths} rows will be skipped unless the filepaths are corrected. "
+            f"Filepaths must be absolute or relative to the directory containing your dataset."
         )
         to_print = click.confirm(
             f"Would you like to print the {num_nonexistent_filepaths} filepaths to console?"

--- a/cleanlab_cli/dataset/upload_types.py
+++ b/cleanlab_cli/dataset/upload_types.py
@@ -7,7 +7,7 @@ class ValidationWarning(Enum):
     MISSING_ID = "MISSING_ID"
     MISSING_VAL = "MISSING_VAL"
     MISSING_FILE = "MISSING_FILE"
-    INVALID_FILE = "INVALID_FILE"
+    UNREADABLE_FILE = "UNREADABLE_FILE"
     TYPE_MISMATCH = "TYPE_MISMATCH"
     DUPLICATE_ID = "DUPLICATE_ID"
 
@@ -17,7 +17,7 @@ def warning_to_readable_name(warning: ValidationWarning) -> str:
         ValidationWarning.MISSING_ID: "Rows with missing IDs (rows are dropped)",
         ValidationWarning.MISSING_FILE: "Rows with non-existent filepaths (rows are dropped)",
         ValidationWarning.MISSING_VAL: "Rows with missing values (values replaced with null)",
-        ValidationWarning.INVALID_FILE: "Rows with invalid files (rows are dropped)",
+        ValidationWarning.UNREADABLE_FILE: "Rows with unreadable files (rows are dropped)",
         ValidationWarning.TYPE_MISMATCH: (
             "Rows with values that do not match the schema (values replaced with null)"
         ),
@@ -35,7 +35,7 @@ class WarningLog:
     MISSING_ID: List[str]
     MISSING_VAL: Dict[str, List[str]]
     MISSING_FILE: Dict[str, List[str]]
-    INVALID_FILE: Dict[str, List[str]]
+    UNREADABLE_FILE: Dict[str, List[str]]
     TYPE_MISMATCH: Dict[str, List[str]]
     DUPLICATE_ID: Dict[str, List[str]]
 
@@ -45,7 +45,7 @@ class WarningLog:
             MISSING_ID=list(),
             MISSING_VAL=dict(),
             MISSING_FILE=dict(),
-            INVALID_FILE=dict(),
+            UNREADABLE_FILE=dict(),
             TYPE_MISMATCH=dict(),
             DUPLICATE_ID=dict(),
         )
@@ -55,7 +55,7 @@ class WarningLog:
             ValidationWarning.MISSING_ID: self.MISSING_ID,
             ValidationWarning.MISSING_VAL: self.MISSING_VAL,
             ValidationWarning.MISSING_FILE: self.MISSING_FILE,
-            ValidationWarning.INVALID_FILE: self.INVALID_FILE,
+            ValidationWarning.UNREADABLE_FILE: self.UNREADABLE_FILE,
             ValidationWarning.TYPE_MISMATCH: self.TYPE_MISMATCH,
             ValidationWarning.DUPLICATE_ID: self.DUPLICATE_ID,
         }[key]

--- a/cleanlab_cli/login/login.py
+++ b/cleanlab_cli/login/login.py
@@ -34,7 +34,7 @@ def login(prev_state: PreviousState, key: str) -> None:
     except json.decoder.JSONDecodeError:
         error("CLI settings are corrupted and could not be read.")
         overwrite = click.confirm(
-            "Would you like to create a new settings file with the provided API key?",
+            "Create a new settings file with the provided API key?",
             default=None,
         )
         if overwrite:

--- a/cleanlab_cli/util.py
+++ b/cleanlab_cli/util.py
@@ -21,9 +21,16 @@ def get_dataset_file_extension(filename: str) -> DatasetFileExtension:
     return DatasetFileExtension(file_extension)
 
 
+def _standardize_image_file_extension(file_extension: str) -> str:
+    file_extension = file_extension.lower()
+    if file_extension == ".jpg":
+        return ".jpeg"
+    return file_extension
+
+
 def get_image_file_extension(filename: str) -> ImageFileExtension:
     file_extension = pathlib.Path(filename).suffix
-    return ImageFileExtension(file_extension)
+    return ImageFileExtension(_standardize_image_file_extension(file_extension))
 
 
 def get_filename(filepath: str) -> str:


### PR DESCRIPTION
- Standardized image errors to two types: `MISSING_FILE` and `UNREADABLE_FILE`. In both cases, the row is skipped, i.e. not uploaded
- Image file paths must either be absolute or relative to **the directory containing the dataset labels file**.
- Shortened most prompts by deleting "Would you like"
- At the end of dataset upload, if this is an image dataset and some rows failed due to missing / unreadable file, the user is prompted if they would like to conclude the upload or pick up later
- Implement logic for getting and using the presigned posts

Note: still debugging some localstack issues