### PR TITLE
Tests: Unit tests for processing values based on datatypes and datetime feature type

### DIFF
--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -221,9 +221,9 @@ def validate_and_process_record(
                 elif col_type == DataType.boolean:
                     if not isinstance(column_value, bool):
                         col_val_lower = str(column_value).lower()
-                        if col_val_lower in ["true", "t", "yes", "1"]:
+                        if col_val_lower in ["true", "t", "yes", "y", "1", "1.0"]:
                             row[column_name] = True
-                        elif col_val_lower in ["false", "f", "no", "0"]:
+                        elif col_val_lower in ["false", "f", "no", "n", "0", "0.0"]:
                             row[column_name] = False
                         else:
                             warning = (

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -68,6 +68,9 @@ def get_value_type(val: Any) -> str:
 
 
 def convert_to_python_type(val: Any, data_type: DataType) -> Any:
+    if isinstance(val, str):  # int("180.0") gives an error
+        if data_type == DataType.integer:
+            return int(float(val))
     return DATA_TYPES_TO_PYTHON_TYPES[data_type](val)
 
 

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -3,16 +3,12 @@ Helper functions for processing and uploading dataset rows
 """
 import asyncio
 import decimal
-import os.path
-import threading
 import queue
-from asyncio import Task
-
-import aiohttp
-import click
-import json
-import pandas as pd
 import re
+import threading
+from asyncio import Task
+from collections import defaultdict
+from sys import getsizeof
 from typing import (
     Optional,
     Dict,
@@ -24,17 +20,27 @@ from typing import (
     Coroutine,
     Union,
 )
-from collections import defaultdict
-from sys import getsizeof
 
+import aiohttp
+import click
+import pandas as pd
 from tqdm import tqdm
 
 from cleanlab_cli import api_service
+from cleanlab_cli import click_helpers
 from cleanlab_cli.classes.dataset import Dataset
+from cleanlab_cli.click_helpers import success, info, progress, abort
 from cleanlab_cli.dataset.image_utils import (
     image_file_readable,
     image_file_exists,
     get_image_filepath,
+)
+from cleanlab_cli.dataset.schema_types import (
+    PYTHON_TYPES_TO_READABLE_STRING,
+    DATA_TYPES_TO_PYTHON_TYPES,
+    DataType,
+    Schema,
+    FeatureType,
 )
 from cleanlab_cli.dataset.upload_types import (
     ValidationWarning,
@@ -52,15 +58,6 @@ from cleanlab_cli.util import (
     init_dataset_from_filepath,
     get_file_size,
 )
-from cleanlab_cli.dataset.schema_types import (
-    PYTHON_TYPES_TO_READABLE_STRING,
-    DATA_TYPES_TO_PYTHON_TYPES,
-    DataType,
-    Schema,
-    FeatureType,
-)
-from cleanlab_cli import click_helpers
-from cleanlab_cli.click_helpers import success, info, progress, abort
 
 
 def get_value_type(val: Any) -> str:
@@ -146,7 +143,7 @@ def validate_and_process_record(
                     warning = (
                         f"{column_name}: expected datetime but unable to parse '{column_value}'"
                         f" with {get_value_type(column_value)} type. Datetime strings must be"
-                        " parsable by pandas.Timestamp().",
+                        " parsable by pandas.Timestamp()",
                         ValidationWarning.TYPE_MISMATCH,
                     )
             elif col_feature_type == FeatureType.filepath:
@@ -173,9 +170,25 @@ def validate_and_process_record(
                     row[column_name] = str(column_value)  # type coercion
                 elif col_type == DataType.integer:
                     if not isinstance(column_value, int):
-                        if isinstance(column_value, str) and column_value.isdigit():
+                        coerced = False
+                        if isinstance(column_value, str):
+                            if column_value.isdigit():  # e.g. '180'
+                                row[column_name] = int(column_value)
+                                coerced = True
+                            else:
+                                try:
+                                    temp = float(column_value)
+                                    if temp == int(temp):
+                                        row[column_name] = int(temp)
+                                        coerced = True
+                                except ValueError:
+                                    pass
+                                    # elif
+                        elif isinstance(column_value, float) and int(column_value) == column_value:
                             row[column_name] = int(column_value)
-                        else:
+                            coerced = True
+
+                        if not coerced:
                             warning = (
                                 f"{column_name}: expected 'int' but got '{column_value}' with"
                                 f" {get_value_type(column_value)} type",

--- a/cleanlab_cli/dataset/upload_helpers.py
+++ b/cleanlab_cli/dataset/upload_helpers.py
@@ -139,6 +139,7 @@ def validate_and_process_record(
                 try:
                     timestamp_value = convert_to_python_type(column_value, col_type)
                     pd.Timestamp(timestamp_value)
+                    row[column_name] = timestamp_value
                 except (ValueError, TypeError):
                     warning = (
                         f"{column_name}: expected datetime but unable to parse '{column_value}'"

--- a/tests/commands/test_schema.py
+++ b/tests/commands/test_schema.py
@@ -13,11 +13,11 @@ import traceback
 
 logger = logging.getLogger(__name__)
 
-sample_csv = os.path.join(abspath(dirname(__file__)), "resources/datasets/sample.csv")
-sample_schema = os.path.join(abspath(dirname(__file__)), "resources/schemas/sample_schema.json")
+sample_csv = os.path.join(abspath(dirname(__file__)), "../resources/datasets/sample.csv")
+sample_schema = os.path.join(abspath(dirname(__file__)), "../resources/schemas/sample_schema.json")
 
 
-def assert_success_else_error_output(test_name, result):
+def assert_success_else_error_output(test_name: str, result):
     if result.exit_code != 0:
         if hasattr(result, "exception"):
             traceback.print_tb(result.exception.__traceback__)
@@ -27,7 +27,7 @@ def assert_success_else_error_output(test_name, result):
         )
 
 
-def test_generate():
+def test_generate() -> None:
     dataset = init_dataset_from_filepath(sample_csv)
     df = dataset.read_file_as_dataframe()
     runner = CliRunner()
@@ -56,7 +56,7 @@ def test_generate():
             assert_success_else_error_output("Schema generation", result)
 
 
-def test_validate():
+def test_validate() -> None:
     dataset = init_dataset_from_filepath(sample_csv)
     df = dataset.read_file_as_dataframe()
     runner = CliRunner()
@@ -75,7 +75,7 @@ def test_validate():
             assert_success_else_error_output("Schema validation", result)
 
 
-def test_check_dataset():
+def test_check_dataset() -> None:
     dataset = init_dataset_from_filepath(sample_csv)
     df = dataset.read_file_as_dataframe()
     runner = CliRunner()

--- a/tests/row_processing/test_boolean_data_type.py
+++ b/tests/row_processing/test_boolean_data_type.py
@@ -11,7 +11,7 @@ from tests.row_processing.utils import process_record_with_fields
 
 class TestBooleanDataType:
     @staticmethod
-    def process_with_integer_numeric(
+    def process_with_boolean(
         record: RecordType,
     ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
         return process_record_with_fields(
@@ -22,77 +22,77 @@ class TestBooleanDataType:
         )
 
     def test_boolean_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": True})
+        row, row_id, warnings = self.process_with_boolean({"x": True})
         assert row["x"] is True
 
     def test_yes_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "yes"})
+        row, row_id, warnings = self.process_with_boolean({"x": "yes"})
         assert row["x"] is True
 
     def test_no_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "no"})
+        row, row_id, warnings = self.process_with_boolean({"x": "no"})
         assert row["x"] is False
 
     def test_true_string_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "true"})
+        row, row_id, warnings = self.process_with_boolean({"x": "true"})
         assert row["x"] is True
 
     def test_false_string_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "false"})
+        row, row_id, warnings = self.process_with_boolean({"x": "false"})
         assert row["x"] is False
 
     def test_t_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "t"})
+        row, row_id, warnings = self.process_with_boolean({"x": "t"})
         assert row["x"] is True
 
     def test_f_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "f"})
+        row, row_id, warnings = self.process_with_boolean({"x": "f"})
         assert row["x"] is False
 
     def test_y_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "y"})
+        row, row_id, warnings = self.process_with_boolean({"x": "y"})
         assert row["x"] is True
 
     def test_n_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "n"})
+        row, row_id, warnings = self.process_with_boolean({"x": "n"})
         assert row["x"] is False
 
     def test_1_string_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "1"})
+        row, row_id, warnings = self.process_with_boolean({"x": "1"})
         assert row["x"] is True
 
     def test_0_string_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "0"})
+        row, row_id, warnings = self.process_with_boolean({"x": "0"})
         assert row["x"] is False
 
     def test_1_integer_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": 1})
+        row, row_id, warnings = self.process_with_boolean({"x": 1})
         assert row["x"] is True
 
     def test_0_integer_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": 0})
+        row, row_id, warnings = self.process_with_boolean({"x": 0})
         assert row["x"] is False
 
     def test_invalid_integer_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": 100})
+        row, row_id, warnings = self.process_with_boolean({"x": 100})
         assert row["x"] is None
 
     def test_invalid_string_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": "ok"})
+        row, row_id, warnings = self.process_with_boolean({"x": "ok"})
         assert row["x"] is None
 
     def test_1_float_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": 1.0})
+        row, row_id, warnings = self.process_with_boolean({"x": 1.0})
         assert row["x"] is True
 
     def test_0_float_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": 0.0})
+        row, row_id, warnings = self.process_with_boolean({"x": 0.0})
         assert row["x"] is False
 
     def test_null_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": None})
+        row, row_id, warnings = self.process_with_boolean({"x": None})
         assert row["x"] is None
 
     def test_nan_input(self) -> None:
-        row, row_id, warnings = self.process_with_integer_numeric({"x": float("nan")})
+        row, row_id, warnings = self.process_with_boolean({"x": float("nan")})
         assert row["x"] is None

--- a/tests/row_processing/test_boolean_data_type.py
+++ b/tests/row_processing/test_boolean_data_type.py
@@ -1,0 +1,90 @@
+from typing import Tuple, Optional
+
+from cleanlab_cli.dataset import (
+    RowWarningsType,
+    DataType,
+    FeatureType,
+)
+from cleanlab_cli.types import RecordType
+from tests.row_processing.utils import process_record_with_fields
+
+
+class TestBooleanDataType:
+    @staticmethod
+    def process_with_integer_numeric(
+        record: RecordType,
+    ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
+        return process_record_with_fields(
+            record=record,
+            fields={
+                "x": dict(data_type=DataType.boolean.value, feature_type=FeatureType.boolean.value)
+            },
+        )
+
+    def test_boolean_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": True})
+        assert row["x"] is True
+
+    def test_yes_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "yes"})
+        assert row["x"] is True
+
+    def test_no_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "no"})
+        assert row["x"] is False
+
+    def test_true_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "true"})
+        assert row["x"] is True
+
+    def test_false_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "false"})
+        assert row["x"] is False
+
+    def test_t_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "t"})
+        assert row["x"] is True
+
+    def test_f_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "f"})
+        assert row["x"] is False
+
+    def test_1_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "1"})
+        assert row["x"] is True
+
+    def test_0_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "0"})
+        assert row["x"] is False
+
+    def test_1_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": 1})
+        assert row["x"] is True
+
+    def test_0_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": 0})
+        assert row["x"] is False
+
+    def test_invalid_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": 100})
+        assert row["x"] is None
+
+    def test_invalid_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "ok"})
+        assert row["x"] is None
+
+    def test_1_float_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": 1.0})
+        assert row["x"] is True
+
+    def test_0_float_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": 0.0})
+        assert row["x"] is False
+
+    def test_null_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": None})
+        assert row["x"] is None
+
+    def test_nan_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": float("nan")})
+        assert row["x"] is None

--- a/tests/row_processing/test_boolean_data_type.py
+++ b/tests/row_processing/test_boolean_data_type.py
@@ -49,6 +49,14 @@ class TestBooleanDataType:
         row, row_id, warnings = self.process_with_integer_numeric({"x": "f"})
         assert row["x"] is False
 
+    def test_y_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "y"})
+        assert row["x"] is True
+
+    def test_n_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"x": "n"})
+        assert row["x"] is False
+
     def test_1_string_input(self) -> None:
         row, row_id, warnings = self.process_with_integer_numeric({"x": "1"})
         assert row["x"] is True

--- a/tests/row_processing/test_datetime_feature_type.py
+++ b/tests/row_processing/test_datetime_feature_type.py
@@ -1,0 +1,125 @@
+from typing import Tuple, Optional
+
+from cleanlab_cli.dataset import (
+    RowWarningsType,
+    FeatureType,
+    DataType,
+)
+from cleanlab_cli.types import RecordType
+from tests.row_processing.utils import process_record_with_fields
+
+
+class TestDatetime:
+    @staticmethod
+    def process_datetime(
+        record: RecordType, data_type: str
+    ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
+        return process_record_with_fields(
+            record=record,
+            fields={
+                "timestamp": dict(data_type=data_type, feature_type=FeatureType.datetime.value)
+            },
+        )
+
+    def test_float_input(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": 180.0}, data_type=DataType.float.value
+        )
+        assert row["timestamp"] == 180.0
+
+    def test_nan_input(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": float("nan")}, data_type=DataType.float.value
+        )
+        assert row["timestamp"] is None
+
+    def test_null_input(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": None}, data_type=DataType.float.value
+        )
+        assert row["timestamp"] is None
+
+    def test_integer_input(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": 189000000}, data_type=DataType.integer.value
+        )
+        assert row["timestamp"] == 189000000
+
+    def test_valid_string_input(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            record={"timestamp": "2015-02-24 11:35:52 -0800"}, data_type=DataType.string.value
+        )
+        assert row["timestamp"] == "2015-02-24 11:35:52 -0800"
+
+    def test_valid_string_input_2(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            record={"timestamp": "2015-02-24"}, data_type=DataType.string.value
+        )
+        assert row["timestamp"] == "2015-02-24"
+
+    def test_valid_string_input_3(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            record={"timestamp": "24 Feb 2015"}, data_type=DataType.string.value
+        )
+        assert row["timestamp"] == "24 Feb 2015"
+
+    def test_valid_string_input_4(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            record={"timestamp": "Feb 24 2015"}, data_type=DataType.string.value
+        )
+        assert row["timestamp"] == "Feb 24 2015"
+
+    def test_invalid_string_input(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            record={"timestamp": "abc"}, data_type=DataType.string.value
+        )
+        assert row["timestamp"] is None
+
+    ## Data type and input type mismatch
+    def test_integer_string_input_with_integer_data_type(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": "189000000"}, data_type=DataType.integer.value
+        )
+        assert row["timestamp"] == 189000000
+
+    def test_invalid_string_input_with_integer_data_type(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": "189000000a"}, data_type=DataType.integer.value
+        )
+        assert row["timestamp"] is None
+
+    def test_float_string_input_with_integer_data_type(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": "189000000.0"}, data_type=DataType.integer.value
+        )
+        assert row["timestamp"] == 189000000  # TODO
+
+    def test_float_input_with_integer_data_type(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": 189000000.0}, data_type=DataType.integer.value
+        )
+        assert row["timestamp"] == 189000000
+
+    def test_integer_string_input_with_float_data_type(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": "189000000"}, data_type=DataType.float.value
+        )
+        assert row["timestamp"] == 189000000.0
+
+    def test_invalid_string_input_with_float_data_type(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": "189000000a"}, data_type=DataType.float.value
+        )
+        assert row["timestamp"] is None
+
+    def test_integer_input_with_string_date_type(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": 189000000}, data_type=DataType.string.value
+        )
+        assert row["timestamp"] is None
+
+    def test_float_input_with_string_date_type(self) -> None:
+        row, row_id, warnings = self.process_datetime(
+            {"timestamp": 189000000.0}, data_type=DataType.string.value
+        )
+        assert row["timestamp"] is None

--- a/tests/row_processing/test_float_data_type.py
+++ b/tests/row_processing/test_float_data_type.py
@@ -1,0 +1,58 @@
+from typing import Tuple, Optional
+
+from cleanlab_cli.dataset import (
+    RowWarningsType,
+    DataType,
+    FeatureType,
+)
+from cleanlab_cli.types import RecordType
+from tests.row_processing.utils import process_record_with_fields
+
+
+class TestFloatDataType:
+    @staticmethod
+    def process_with_float(
+        record: RecordType,
+    ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
+        return process_record_with_fields(
+            record=record,
+            fields={
+                "x": dict(data_type=DataType.float.value, feature_type=FeatureType.numeric.value)
+            },
+        )
+
+    # def test_boolean_input(self) -> None:
+    #     row, row_id, warnings = self.process_with_float({"x": True})
+    #     assert row["x"] is None
+
+    def test_float_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_float({"x": "180.0"})
+        assert row["x"] == 180.0
+
+    def test_integer_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_float({"x": "180"})
+        assert row["x"] == 180.0
+
+    def test_invalid_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_float({"x": "cc982"})
+        assert row["x"] is None
+
+    def test_percentage_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_float({"x": "180%"})
+        assert row["x"] == 180.0
+
+    def test_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_float({"x": 180})
+        assert row["x"] == 180
+
+    def test_float_input(self) -> None:
+        row, row_id, warnings = self.process_with_float({"x": 180.0})
+        assert row["x"] == 180.0
+
+    def test_nan_input(self) -> None:
+        row, row_id, warnings = self.process_with_float({"x": float("nan")})
+        assert row["x"] is None
+
+    def test_null_input(self) -> None:
+        row, row_id, warnings = self.process_with_float({"x": None})
+        assert row["x"] is None

--- a/tests/row_processing/test_integer_data_type.py
+++ b/tests/row_processing/test_integer_data_type.py
@@ -9,7 +9,7 @@ from cleanlab_cli.types import RecordType
 from tests.row_processing.utils import process_record_with_fields
 
 
-class TestIntegerNumeric:
+class TestIntegerDataType:
     @staticmethod
     def process_with_integer_numeric(
         record: RecordType,

--- a/tests/row_processing/test_integer_data_type.py
+++ b/tests/row_processing/test_integer_data_type.py
@@ -1,0 +1,56 @@
+from typing import Tuple, Optional
+
+from cleanlab_cli.dataset import (
+    RowWarningsType,
+    DataType,
+    FeatureType,
+)
+from cleanlab_cli.types import RecordType
+from tests.row_processing.utils import process_record_with_fields
+
+
+class TestIntegerNumeric:
+    @staticmethod
+    def process_with_integer_numeric(
+        record: RecordType,
+    ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
+        return process_record_with_fields(
+            record=record,
+            fields={
+                "height": dict(
+                    data_type=DataType.integer.value, feature_type=FeatureType.numeric.value
+                )
+            },
+        )
+
+    def test_float_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": 180.0})
+        assert row["height"] == 180
+
+    def test_float_non_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": 180.5})
+        assert row["height"] is None
+
+    def test_string_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": "180"})
+        assert row["height"] == 180
+
+    def test_string_non_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": "180a"})
+        assert row["height"] is None
+
+    def test_float_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": "180.0"})
+        assert row["height"] == 180
+
+    def test_scientific_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": "1e9"})
+        assert row["height"] == 1000000000
+
+    def test_null_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": None})
+        assert row["height"] is None
+
+    def test_nan_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": float("nan")})
+        assert row["height"] is None

--- a/tests/row_processing/test_integer_data_type.py
+++ b/tests/row_processing/test_integer_data_type.py
@@ -43,6 +43,10 @@ class TestIntegerDataType:
         row, row_id, warnings = self.process_with_integer_numeric({"height": "180.0"})
         assert row["height"] == 180
 
+    def test_float_string_input_2(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": "180.5"})
+        assert row["height"] is None
+
     def test_scientific_input(self) -> None:
         row, row_id, warnings = self.process_with_integer_numeric({"height": "1e9"})
         assert row["height"] == 1000000000

--- a/tests/row_processing/test_integer_data_type.py
+++ b/tests/row_processing/test_integer_data_type.py
@@ -47,6 +47,10 @@ class TestIntegerNumeric:
         row, row_id, warnings = self.process_with_integer_numeric({"height": "1e9"})
         assert row["height"] == 1000000000
 
+    def test_boolean_input(self) -> None:
+        row, row_id, warnings = self.process_with_integer_numeric({"height": True})
+        assert row["height"] == 1
+
     def test_null_input(self) -> None:
         row, row_id, warnings = self.process_with_integer_numeric({"height": None})
         assert row["height"] is None

--- a/tests/row_processing/test_string_data_type.py
+++ b/tests/row_processing/test_string_data_type.py
@@ -1,0 +1,46 @@
+from typing import Tuple, Optional
+
+from cleanlab_cli.dataset import RowWarningsType, DataType, FeatureType
+from cleanlab_cli.types import RecordType
+from tests.row_processing.utils import process_record_with_fields
+
+
+class TestStringDataType:
+    @staticmethod
+    def process_with_string_data_type(
+        record: RecordType,
+    ) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
+        return process_record_with_fields(
+            record=record,
+            fields={
+                "height": dict(data_type=DataType.string.value, feature_type=FeatureType.text.value)
+            },
+        )
+
+    def test_float_input(self) -> None:
+        row, row_id, warnings = self.process_with_string_data_type({"height": 180.5})
+        assert row["height"] == "180.5"
+
+    def test_string_input(self) -> None:
+        row, row_id, warnings = self.process_with_string_data_type({"height": "180cm"})
+        assert row["height"] == "180cm"
+
+    def test_integer_input(self) -> None:
+        row, row_id, warnings = self.process_with_string_data_type({"height": 180})
+        assert row["height"] == "180"
+
+    def test_boolean_input(self) -> None:
+        row, row_id, warnings = self.process_with_string_data_type({"height": True})
+        assert row["height"] == "True"
+
+    def test_scientific_input(self) -> None:
+        row, row_id, warnings = self.process_with_string_data_type({"height": 1e9})
+        assert row["height"] == "1000000000.0"
+
+    def test_null_input(self) -> None:
+        row, row_id, warnings = self.process_with_string_data_type({"height": None})
+        assert row["height"] is None
+
+    def test_nan_input(self) -> None:
+        row, row_id, warnings = self.process_with_string_data_type({"height": float("nan")})
+        assert row["height"] is None

--- a/tests/row_processing/utils.py
+++ b/tests/row_processing/utils.py
@@ -1,0 +1,31 @@
+from typing import Tuple, Optional, Dict
+
+from cleanlab_cli import SCHEMA_VERSION
+from cleanlab_cli.classes.dataset import Dataset
+from cleanlab_cli.dataset import validate_and_process_record, Schema, RowWarningsType
+from cleanlab_cli.dataset.schema_types import SchemaMetadata
+from cleanlab_cli.types import RecordType
+
+ID_COLUMN = "id"
+
+
+def initialize_schema_from_fields(fields: Dict[str, Dict[str, str]]) -> Schema:
+    schema_metadata = dict(
+        id_column=ID_COLUMN, modality="tabular", name="dummy_file", filepath_column=None
+    )
+    return Schema.create(metadata=schema_metadata, fields=fields, version=SCHEMA_VERSION)
+
+
+def process_record_with_fields(
+    record: RecordType, fields: Dict[str, Dict[str, str]]
+) -> Tuple[Optional[RecordType], Optional[str], Optional[RowWarningsType]]:
+    record[ID_COLUMN] = "id"
+    schema = initialize_schema_from_fields(fields)
+    row, row_id, warnings = validate_and_process_record(
+        dataset=Dataset(filepath="dummy_filepath.csv"),
+        schema=schema,
+        record=record,
+        seen_ids=set(),
+        existing_ids=set(),
+    )
+    return row, row_id, warnings

--- a/tests/unit/test_extract_float_string.py
+++ b/tests/unit/test_extract_float_string.py
@@ -1,0 +1,15 @@
+from cleanlab_cli.dataset import extract_float_string
+
+
+class TestExtractFloatString:
+    def test_percentage_string(self):
+        assert extract_float_string("180.5%") == "180.5"
+
+    def test_dollar_string(self):
+        assert extract_float_string("$180.5") == "180.5"
+
+    def test_float_string(self):
+        assert extract_float_string("180.5") == "180.5"
+
+    def test_invalid_string(self):
+        assert extract_float_string("c2ab3") == ""


### PR DESCRIPTION
Introduces a new test suite at `tests/row_processing` that checks that dataset values are parsed / handled correctly based on the specified schema data type / feature type. 

Unit tests for the `extract_float_string` function are also introduced.

This test suite actually caught several bugs, which are fixed in this PR as well.

- Fixes bug where 'whole' floats like 1.0, 2.0, etc were not correctly cast to the corresponding integer when the data type is set to `integer` (fixes issue: https://github.com/cleanlab/cleanlab-studio/issues/574)
- Fixes bug where float strings (e.g. `'180.0'`) were replaced with `None` for `integer` data type. Now fixed so that this is converted to `180`. Note that `180.5` is still replaced by `None`.
- Fixes bug where for datetime feature types, if the value was a string and the datatype was float / int, the string was not cast to the specified data type
- Fixes bug where 1.0 and 0.0 were not recognized as boolean values. (Also includes `y` and `n` as accepted boolean strings)
- One unfixed bug: regex for `extract_float_string` is too aggressive -- alphanumeric strings like `c2ab3` result in `2` being returned instead of null